### PR TITLE
chore: adjust spotlight in product type

### DIFF
--- a/packages/strapi-dashboard/src/api/product/content-types/product/schema.json
+++ b/packages/strapi-dashboard/src/api/product/content-types/product/schema.json
@@ -94,16 +94,6 @@
       },
       "component": "components.catalogi-meta",
       "required": false
-    },
-    "spotlightSection": {
-      "type": "component",
-      "repeatable": false,
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "component": "components.spotlight"
     }
   }
 }

--- a/packages/strapi-dashboard/src/components/sections/flexible-section.json
+++ b/packages/strapi-dashboard/src/components/sections/flexible-section.json
@@ -28,7 +28,7 @@
     "option2": {
       "type": "richtext"
     },
-    "spotlightAside": {
+    "spotlight": {
       "type": "component",
       "repeatable": false,
       "component": "components.spotlight"


### PR DESCRIPTION
the reason why, because currently we don't use flexible zone for adding section or component to the product page, the next step is to make the spotlight as component used inside the flexibleSections as aside. The second usage is as separate sections