### PR TITLE
chore: improve the docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,13 @@ FROM build AS production
 COPY --from=builder /opt/app /opt/app
 COPY --from=dependencies /prod_node_modules /opt/app/node_modules
 
-RUN chmod +x ./bin/wait-for-it.sh
+RUN set -eux; \
+    chmod +x ./bin/wait-for-it.sh && \
+    addgroup --system --gid 1001 pdcgroup && \
+    adduser --system --uid 1001 --ingroup pdcgroup pdcuser && \
+    chown -R pdcuser:pdcgroup /opt/app
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
-RUN chown -R nextjs:nodejs /opt/app
-USER nextjs
+USER pdcuser
 
 ENV NODE_ENV=${NODE_ENV}
 EXPOSE 1337


### PR DESCRIPTION
- [x] use `&&` to combine multi commands to reduce the number of separate layers created during the build process
- [x] rename the created group and user - [x] **group**: `nodejs` => `pdcgroup` - [x] **user**: `nextjs` => `pdcuser`
- [x] using `set -eux` in a Dockerfile ensures that any errors or issues during the build process are identified and reported early. It helps with debugging and prevents the build from proceeding if any command fails or references unset variables. [**references**](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)