### PR TITLE
chore: set the pando-search response limit to 5

### DIFF
--- a/apps/frontend/src/app/[locale]/search/[query]/page.tsx
+++ b/apps/frontend/src/app/[locale]/search/[query]/page.tsx
@@ -52,7 +52,7 @@ const Search = async ({ params: { locale, query } }: SearchProps) => {
     'use server';
     const searchResults = await getSuggestedSearch(locale, query, {
       page: pageIndex + 1,
-      size: 10,
+      size: 5,
     });
 
     return {

--- a/apps/frontend/src/app/[locale]/search/actions.ts
+++ b/apps/frontend/src/app/[locale]/search/actions.ts
@@ -8,7 +8,7 @@ type Params = {
   page?: number;
 };
 
-export const getSuggestedSearch = async (locale: string, value: string, params: Params = { page: 1, size: 10 }) => {
+export const getSuggestedSearch = async (locale: string, value: string, params: Params = { page: 1, size: 5 }) => {
   const urlParams = {
     q: encodeURIComponent(value),
     track: false,


### PR DESCRIPTION
the reason to demonstrate the load-more button, because we currently using the pando-search development-url that has small amount of results