### PR TITLE
fix: add spacing tokens value to spotlight component

### DIFF
--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -7,7 +7,8 @@ body {
   --utrecht-search-bar-dropdown-padding-inline-end: 1rem;
   --utrecht-search-bar-list-item-padding-block-start: 6px;
   --utrecht-search-bar-list-item-padding-block-end: 6px;
-
+  --utrecht-spotlight-section-margin-block-start: 16px;
+  --utrecht-spotlight-section-margin-block-end: 16px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
     "Droid Sans", "Helvetica Neue", sans-serif;
   margin-block: 0;


### PR DESCRIPTION
this is a temperately until we add it from the utrecht theme package