### PR TITLE
fix: set price field label to required to prevent `null` issue

### DIFF
--- a/apps/strapi-dashboard/src/api/price/content-types/price/schema.json
+++ b/apps/strapi-dashboard/src/api/price/content-types/price/schema.json
@@ -19,7 +19,9 @@
       "component": "components.price"
     },
     "title": {
-      "type": "string"
+      "type": "string",
+      "unique": true,
+      "required": true
     },
     "products": {
       "type": "relation",

--- a/apps/strapi-dashboard/src/components/components/price.json
+++ b/apps/strapi-dashboard/src/components/components/price.json
@@ -8,17 +8,22 @@
   "options": {},
   "attributes": {
     "label": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "currency": {
       "type": "enumeration",
-      "enum": ["EUR", "USD"],
-      "required": false,
+      "enum": [
+        "EUR",
+        "USD"
+      ],
+      "required": true,
       "default": "EUR"
     },
     "value": {
       "type": "decimal",
-      "required": true
+      "required": true,
+      "min": 0
     }
   }
 }


### PR DESCRIPTION
- [x] Set the price page title field to required and unique
- [x] add validation to the value field
- [x] set the currency to required