### PR TITLE
feat: add parent relation to thema and thema-content

### DIFF
--- a/apps/vth-dashboard/src/api/thema-content/content-types/thema-content/schema.json
+++ b/apps/vth-dashboard/src/api/thema-content/content-types/thema-content/schema.json
@@ -22,6 +22,11 @@
       "type": "string",
       "required": true,
       "minLength": 2
+    },
+    "parent": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::thema.thema"
     }
   }
 }

--- a/apps/vth-dashboard/src/api/thema/content-types/thema/schema.json
+++ b/apps/vth-dashboard/src/api/thema/content-types/thema/schema.json
@@ -23,6 +23,11 @@
       "type": "string",
       "unique": true,
       "required": true
+    },
+    "parent": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::thema.thema"
     }
   }
 }


### PR DESCRIPTION
Adds parent relation between `thema` and `thema-content`. This allows sub-themas and linking thema-contents directly to main themas.