### PR TITLE
chore: remove yarn from nextjs apps dependencies

### DIFF
--- a/apps/pdc-frontend/package.json
+++ b/apps/pdc-frontend/package.json
@@ -43,8 +43,7 @@
     "rehype-raw": "6.1.1",
     "sharp": "0.32.1",
     "vega": "5.25.0",
-    "vega-lite": "5.14.1",
-    "yarn": "1.22.19"
+    "vega-lite": "5.14.1"
   },
   "devDependencies": {
     "eslint": "8.35.0",

--- a/apps/vth-frontend/package.json
+++ b/apps/vth-frontend/package.json
@@ -39,8 +39,7 @@
     "rehype-raw": "6.1.1",
     "sharp": "0.32.1",
     "vega": "5.25.0",
-    "vega-lite": "5.14.1",
-    "yarn": "1.22.19"
+    "vega-lite": "5.14.1"
   },
   "devDependencies": {
     "eslint": "8.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19978,7 +19978,7 @@ yargs@^17.0.0, yargs@^17.2.1, yargs@^17.7.1, yargs@~17.7.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yarn@1.22.19, yarn@^1.22.19:
+yarn@^1.22.19:
   version "1.22.19"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
   integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==


### PR DESCRIPTION
I believe that we mistakenly installed Yarn as a dependency in our Next.js applications.