### PR TITLE
feat(vth): add banner image

### DIFF
--- a/apps/vth-dashboard/src/api/homepage/content-types/homepage/schema.json
+++ b/apps/vth-dashboard/src/api/homepage/content-types/homepage/schema.json
@@ -22,6 +22,11 @@
     },
     "description": {
       "type": "text"
+    },
+    "bannerImage": {
+      "allowedTypes": ["images"],
+      "type": "media",
+      "multiple": false
     }
   }
 }

--- a/apps/vth-dashboard/src/api/thema-content/content-types/thema-content/schema.json
+++ b/apps/vth-dashboard/src/api/thema-content/content-types/thema-content/schema.json
@@ -33,9 +33,10 @@
       "mappedBy": "child_contents"
     },
     "previewImage": {
-      "allowedTypes": ["images", "files", "videos", "audios"],
       "type": "media",
-      "multiple": false
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
     }
   }
 }

--- a/apps/vth-dashboard/src/api/thema/content-types/thema/schema.json
+++ b/apps/vth-dashboard/src/api/thema/content-types/thema/schema.json
@@ -46,9 +46,10 @@
       "type": "text"
     },
     "previewImage": {
-      "allowedTypes": ["images", "files", "videos", "audios"],
       "type": "media",
-      "multiple": false
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
     }
   }
 }

--- a/apps/vth-frontend/src/app/[locale]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { createStrapiURL } from '@frameless/vth-frontend/src/util/createStrapiUR
 import { fetchData } from '@frameless/vth-frontend/src/util/fetchData';
 import { Heading1 } from '@utrecht/component-library-react';
 import { Metadata } from 'next';
+import Image from 'next/image';
 import React from 'react';
 import { Card } from '@/components/Card';
 import { Grid } from '@/components/Grid';
@@ -37,33 +38,46 @@ const Home = async ({ params: { locale } }: { params: any }) => {
     variables: { locale: locale },
   });
 
-  const { title, content } = data?.homepage?.data?.attributes;
+  const { title, content, bannerImage } = data?.homepage?.data?.attributes;
   const themas = data?.themas?.data;
+  const bannerAttributes = bannerImage?.data?.attributes;
 
   return (
-    <Grid className={'utrecht-grid--content-padding'}>
-      <div className={'utrecht-grid__two-third'}>
-        <Heading1>{title}</Heading1>
-        <Markdown strapiBackendURL={process.env.STRAPI_PUBLIC_URL}>{content}</Markdown>
-      </div>
-      <Grid className={'utrecht-grid__full-width'}>
-        {themas &&
-          themas.map((thema: any) => {
-            const { title, description, slug, previewImage: imageData } = thema.attributes;
-            const imageUrl = imageData?.data?.attributes?.url;
-            return (
-              <Card
-                className={'utrecht-grid__one-third'}
-                key={`thema-${slug}`}
-                title={title}
-                description={description}
-                image={{ url: imageUrl && buildImgURL(imageUrl), alt: '' }}
-                link={{ href: `/themas/${slug}` }}
-              />
-            );
-          })}
+    <div>
+      {bannerAttributes?.url && (
+        <Image
+          width={1200}
+          height={400}
+          src={buildImgURL(bannerAttributes.url)}
+          alt={bannerAttributes.alternativeText || ''}
+          priority
+          className={'utrecht-image utrecht-image--banner'}
+        />
+      )}
+      <Grid className={'utrecht-grid--content-padding'}>
+        <div className={'utrecht-grid__two-third'}>
+          <Heading1>{title}</Heading1>
+          <Markdown strapiBackendURL={process.env.STRAPI_PUBLIC_URL}>{content}</Markdown>
+        </div>
+        <Grid className={'utrecht-grid__full-width'}>
+          {themas &&
+            themas.map((thema: any) => {
+              const { title, description, slug, previewImage: imageData } = thema.attributes;
+              const imageUrl = imageData?.data?.attributes?.url;
+              return (
+                <Card
+                  className={'utrecht-grid__one-third'}
+                  key={`thema-${slug}`}
+                  title={title}
+                  description={description}
+                  image={{ url: imageUrl && buildImgURL(imageUrl), alt: '' }}
+                  link={{ href: `/themas/${slug}` }}
+                />
+              );
+            })}
+        </Grid>
       </Grid>
-    </Grid>
+    </div>
   );
 };
 

--- a/apps/vth-frontend/src/components/Card/index.style.css
+++ b/apps/vth-frontend/src/components/Card/index.style.css
@@ -4,6 +4,7 @@
 }
 
 .utrecht-card__image {
+  max-width: 100%;
   object-fit: cover;
 }
 

--- a/apps/vth-frontend/src/components/Logo/index.tsx
+++ b/apps/vth-frontend/src/components/Logo/index.tsx
@@ -5,7 +5,7 @@ interface LogoProps {
   locale: string;
 }
 export const Logo = ({ locale }: LogoProps) => (
-  <Link href={`/${locale}`} className="utrecht-link" prefetch={false} aria-label="Gemeente Utrecht Logo">
+  <Link href={`/${locale}`} className="utrecht-link" prefetch={true} aria-label="Gemeente Utrecht Logo">
     <svg width="188" height="101" viewBox="0 0 188 101" fill="none">
       <g clipPath="url(#clip0_908_6411)">
         <path

--- a/apps/vth-frontend/src/query/index.ts
+++ b/apps/vth-frontend/src/query/index.ts
@@ -20,6 +20,14 @@ query getHomePage {
       attributes {
         title
         content
+        bannerImage {
+          data {
+            attributes {
+              url
+              alternativeText
+            }
+          }
+        }
       }
     }
   }

--- a/apps/vth-frontend/src/query/index.ts
+++ b/apps/vth-frontend/src/query/index.ts
@@ -64,6 +64,7 @@ query GET_THEMA_BY_SLUG($slug: String) {
               attributes {
                 title,
                 slug,
+                description,
                 previewImage {
                   data {
                     attributes {
@@ -79,6 +80,7 @@ query GET_THEMA_BY_SLUG($slug: String) {
               attributes {
                 title,
                 slug,
+                description,
                 previewImage {
                   data {
                     attributes {
@@ -94,6 +96,7 @@ query GET_THEMA_BY_SLUG($slug: String) {
               attributes {
                 title,
                 slug,
+                description,
                 previewImage {
                   data {
                     attributes {

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -14,6 +14,8 @@ body {
   /* nav */
   --utrecht-navigation-border-block-start-width: 1px;
   --utrecht-navigation-border-block-start-color: var(--utrecht-color-grey-80);
+  --utrecht-navigation-border-block-end-width: 1px;
+  --utrecht-navigation-border-block-end-color: var(--utrecht-color-grey-80);
 
   /* nav-list */
 
@@ -107,7 +109,7 @@ a {
 
 .utrecht-page-header {
   --utrecht-page-header-padding-block-start: 0;
-  --utrecht-page-header-padding-block-end: 0;
+  --utrecht-page-header-padding-block-end: 1rem;
   --utrecht-page-padding-inline-start: 0;
   --utrecht-page-padding-inline-end: 0;
 
@@ -140,4 +142,10 @@ a {
 .utrecht-navigation__toggle-button {
   float: right;
   position: absolute;
+}
+
+.utrecht-navigation {
+  border-block-end-color: var(--utrecht-navigation-border-block-start-color);
+  border-block-end-style: solid;
+  border-block-end-width: var(--utrecht-navigation-border-block-start-width);
 }

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -130,3 +130,14 @@ a {
 .utrecht-link-social {
   border-style: none !important;
 }
+
+.utrecht-image--banner {
+  border-top: 5px solid var(--utrecht-color-red-40);
+  max-height: 300px;
+  object-fit: cover;
+}
+
+.utrecht-navigation__toggle-button {
+  float: right;
+  position: absolute;
+}

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -134,7 +134,6 @@ a {
 }
 
 .utrecht-image--banner {
-  border-top: 5px solid var(--utrecht-color-red-40);
   max-height: 300px;
   object-fit: cover;
 }


### PR DESCRIPTION
<img width="1181" alt="image" src="https://github.com/frameless/strapi/assets/24610692/07ef6ac9-fdf5-44f2-a201-326daf386d78">


### Added
- Banner image on homepage
- Red accent above banner image as separation
- Banner image upload in strapi for the homepage type

### Fixes
- Disallow all media types except images for previously added preview images on card
- Card image sizing
- Card description not showing on thema pages
- (temporary fix): Float menu button into header
- (temporary fix): Add `padding-block-end` to header
- (temporary fix): Add `border-block-end` to navigation