### PR TITLE
fix(pdc-frontend): fix the `useOptimistic` issue

### DIFF
--- a/apps/pdc-frontend/global.d.ts
+++ b/apps/pdc-frontend/global.d.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-unused-vars */
+import { ReactNode, Ref } from 'react';
+
+declare module 'react' {
+  function experimental_useOptimistic<State>(
+    passthrough: State,
+  ): [State, (action: State | ((pendingState: State) => State)) => void];
+  function experimental_useOptimistic<State, Action>(
+    passthrough: State,
+    reducer: (state: State, action: Action) => State,
+  ): [State, (action: Action) => void];
+}

--- a/apps/pdc-frontend/src/components/SearchBar/index.tsx
+++ b/apps/pdc-frontend/src/components/SearchBar/index.tsx
@@ -3,7 +3,7 @@
 import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useOptimistic } from 'react';
+import { experimental_useOptimistic as useOptimistic } from 'react';
 import React from 'react';
 import { Link as UtrechtLink } from '@/components';
 import { SuggestedHits, Suggestions } from '@/types';


### PR DESCRIPTION
This is a temporary solution until we discover the root cause of the issue. Normally, we obtain react types from Next.js under the experimental when we use server action. However, currently, we obtain them from Canary.