### PR TITLE
fix(vth): card style with link underline

### DIFF
--- a/apps/vth-frontend/src/components/Card/index.style.css
+++ b/apps/vth-frontend/src/components/Card/index.style.css
@@ -1,14 +1,14 @@
 .utrecht-card {
-  --utrecht-link-text-decoration: none;
-
   background-color: var(--utrecht-color-blue-90);
   max-width: 312px;
 }
 
 .utrecht-card:hover {
   --utrecht-link-text-decoration: underline;
+  --utrecht-link-text-decoration-thickness: var(--utrecht-link-hover-text-decoration-thickness);
 
   cursor: pointer;
+  text-decoration-skip-ink: none;
 }
 
 .utrecht-card__image {


### PR DESCRIPTION
Removes a text decoration overwrite to make sure all card links retain their underline. Adds a few card hover styles to ensure the underline is identical when hovering over the card and hovering over the link specifically.