### PR TITLE
feat(ui): support sub links in navigation

### DIFF
--- a/apps/vth-frontend/src/app/[locale]/layout.tsx
+++ b/apps/vth-frontend/src/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { dir } from 'i18next';
 import type { Metadata } from 'next';
 import React from 'react';
 import { QueryClientProvider } from '@/client';
-import { Navigation, Page, PageContent, PageHeader } from '@/components';
+import { Navigation, NavigationListType, Page, PageContent, PageHeader } from '@/components';
 import '@utrecht/component-library-css';
 import '../../styles/globals.css';
 import '@utrecht/design-tokens/dist/index.css';
@@ -64,7 +64,7 @@ const RootLayout = async ({ children, params: { locale } }: LayoutProps) => {
     return {
       title: thema.attributes.title,
       link: `/themas/${thema.attributes.slug}`,
-    };
+    } satisfies NavigationListType;
   });
 
   const footerData = {

--- a/packages/ui/src/components/Navigation/NavigationItem/index.module.scss
+++ b/packages/ui/src/components/Navigation/NavigationItem/index.module.scss
@@ -14,7 +14,8 @@
 
   align-items: center;
   display: flex;
-  justify-content: center;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .utrecht-navigation__item-icon::before {

--- a/packages/ui/src/components/Navigation/NavigationList/index.module.scss
+++ b/packages/ui/src/components/Navigation/NavigationList/index.module.scss
@@ -28,3 +28,9 @@
     inline-size: 50%;
   }
 }
+
+.utrecht-navigation__list .utrecht-navigation__list {
+  inline-size: 100%;
+  padding-block-end: 0;
+  padding-block-start: 0;
+}

--- a/packages/ui/src/components/Navigation/NavigationList/index.tsx
+++ b/packages/ui/src/components/Navigation/NavigationList/index.tsx
@@ -3,11 +3,7 @@ import { DetailedHTMLProps, ForwardedRef, forwardRef, HTMLAttributes, PropsWithC
 import styles from './index.module.scss';
 import { NavigationItem } from '../NavigationItem';
 import { NavigationLink } from '../NavigationLink';
-
-type NavigationListType = {
-  title: string;
-  link: string;
-};
+import { NavigationListType } from '../index';
 
 interface NavigationListProps extends DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> {
   list: NavigationListType[];
@@ -37,6 +33,9 @@ export const NavigationList = forwardRef(
             <NavigationLink mobile={mobile} href={item.link}>
               {item.title}
             </NavigationLink>
+            {mobile && item.children && item.children.length > 0 && (
+              <NavigationList list={item.children} mobile={mobile} />
+            )}
           </NavigationItem>
         ))}
     </ul>

--- a/packages/ui/src/components/Navigation/index.module.scss
+++ b/packages/ui/src/components/Navigation/index.module.scss
@@ -13,5 +13,4 @@
   display: flex;
   flex-direction: column;
   inline-size: 100%;
-  justify-content: flex-end;
 }

--- a/packages/ui/src/components/Navigation/index.tsx
+++ b/packages/ui/src/components/Navigation/index.tsx
@@ -8,9 +8,10 @@ import { Drawer } from '../Drawer';
 import { Portal } from '../Portal';
 const css = classnames.bind(styles);
 
-type NavigationListType = {
+export type NavigationListType = {
   title: string;
   link: string;
+  children?: NavigationListType[];
 };
 
 interface NavigationProps extends HTMLAttributes<HTMLElement> {


### PR DESCRIPTION
Adds support for navigation sub links in the mobile view. This is required by the VTH project, and creates a starting point for us to fully support sub navigational links in non-mobile views as well should we wish to have them. Also exported the navigation item type for easier use by consuming projects.