### PR TITLE
feat(vth): enable preview for content

### DIFF
--- a/apps/vth-dashboard/config/plugins.ts
+++ b/apps/vth-dashboard/config/plugins.ts
@@ -1,9 +1,6 @@
 const { apolloPrometheusPlugin } = require('strapi-prometheus');
 
-export default () => ({
-  ckeditor5: {
-    enabled: false,
-  },
+export default ({ env }) => ({
   'strapi-tiptap-editor': {
     enabled: true,
   },
@@ -33,6 +30,14 @@ export default () => ({
           references: 'title',
         },
       },
+    },
+  },
+  'preview-button': {
+    enabled: true,
+    config: {
+      domain: env('FRONTEND_PUBLIC_URL'),
+      token: env('PREVIEW_SECRET_TOKEN'),
+      slug: 'thema-content',
     },
   },
   upload: {

--- a/apps/vth-dashboard/package.json
+++ b/apps/vth-dashboard/package.json
@@ -16,6 +16,7 @@
     "clean": "rimraf build .cache dist"
   },
   "dependencies": {
+    "@frameless/preview-button": "0.0.0-semantically-released",
     "@frameless/strapi-tiptap-editor": "0.0.0-semantically-released",
     "@strapi/plugin-graphql": "4.14.4",
     "@strapi/plugin-i18n": "4.14.4",

--- a/apps/vth-frontend/src/app/[locale]/themas/[themaSlug]/content/[contentSlug]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/themas/[themaSlug]/content/[contentSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { createStrapiURL } from '@frameless/vth-frontend/src/util/createStrapiURL';
 import { fetchData } from '@frameless/vth-frontend/src/util/fetchData';
 import { Metadata } from 'next';
+import { draftMode } from 'next/headers';
 import React from 'react';
 import { AccordionProvider, Heading1 } from '@/components';
 import { BreadcrumbNavigationElement } from '@/components/BreadcrumbNavigation';
@@ -21,10 +22,11 @@ type Params = {
 
 export async function generateMetadata({ params: { locale, contentSlug } }: Params): Promise<Metadata> {
   // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { isEnabled } = draftMode();
   const { data } = await fetchData({
     url: createStrapiURL(),
     query: GET_CONTENT_BY_SLUG,
-    variables: { slug: contentSlug, locale: locale },
+    variables: { slug: contentSlug, pageMode: isEnabled ? 'preview' : 'live', locale: locale },
   });
   return {
     title: data.findSlug.data.attributes.title,
@@ -33,10 +35,11 @@ export async function generateMetadata({ params: { locale, contentSlug } }: Para
 }
 
 const Thema = async ({ params: { locale, contentSlug } }: Params) => {
+  const { isEnabled } = draftMode();
   const { data } = await fetchData({
     url: createStrapiURL(),
     query: GET_CONTENT_BY_SLUG,
-    variables: { slug: contentSlug, locale: locale },
+    variables: { slug: contentSlug, pageMode: isEnabled ? 'preview' : 'live', locale: locale },
   });
 
   const { title, content, parents } = data.findSlug.data.attributes;

--- a/apps/vth-frontend/src/app/api/clear-preview/route.ts
+++ b/apps/vth-frontend/src/app/api/clear-preview/route.ts
@@ -1,0 +1,7 @@
+import { draftMode } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export async function GET(_request: Request) {
+  draftMode().disable();
+  redirect('/');
+}

--- a/apps/vth-frontend/src/app/api/preview/route.ts
+++ b/apps/vth-frontend/src/app/api/preview/route.ts
@@ -1,0 +1,43 @@
+import { draftMode } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { GET_CONTENT_BY_SLUG } from '@/query';
+import { createStrapiURL } from '@/util/createStrapiURL';
+import { fetchData } from '@/util/fetchData';
+
+export async function GET(request: Request) {
+  // Parse query string parameters
+  const { searchParams } = new URL(request.url);
+  const secret = searchParams.get('secret');
+  const slug = searchParams.get('slug');
+  const type = searchParams.get('type');
+
+  // Check the secret and next parameters
+  // This secret should only be known to this route handler and the CMS
+  if (secret !== process.env.PREVIEW_SECRET_TOKEN) {
+    return new Response('Invalid token', { status: 401 });
+  } else if (!slug || !type) {
+    return new Response('Missing required parameters', { status: 422 });
+  }
+
+  // Fetch the headless CMS to check if the provided `slug` exists
+  const { data } = await fetchData({
+    url: createStrapiURL(),
+    query: GET_CONTENT_BY_SLUG,
+    variables: {
+      slug: slug,
+      pageMode: 'preview',
+    },
+  });
+
+  // If the slug doesn't exist prevent draft mode from being enabled
+  if (!data) {
+    return new Response('Invalid slug', { status: 401 });
+  }
+
+  const path = `/themas/dieren/content/${slug}`;
+  // Enable Draft Mode by setting the cookie
+  draftMode().enable();
+  // Redirect to the path from the fetched post
+  // We don't redirect to searchParams.slug as that might lead to open redirect vulnerabilities
+  redirect(path);
+}

--- a/apps/vth-frontend/src/query/index.ts
+++ b/apps/vth-frontend/src/query/index.ts
@@ -149,8 +149,8 @@ query GET_THEMA_BY_SLUG($slug: String) {
 }`);
 
 export const GET_CONTENT_BY_SLUG = gql(`
-query GET_CONTENT_BY_SLUG($slug: String) {
-  findSlug(modelName:"thema-content", slug: $slug){
+query GET_CONTENT_BY_SLUG($slug: String, $pageMode: String) {
+  findSlug(modelName:"thema-content", slug: $slug, publicationState: $pageMode) {
     ... on ThemaContentEntityResponse{
       data{
         id


### PR DESCRIPTION
Preview working for content pages. 

Extras:
- [ ] Refactor content fetching to separate function to reduce duplicate code
- [ ] Add preview for thema as well (multiple slug and url path support), bit more work but vague idea of how to