### PR TITLE
fix(strapi-tiptap-editor): resolve table Menubar option issue

### DIFF
--- a/packages/strapi-tiptap-editor/admin/src/components/Editor/TableMenuBar.tsx
+++ b/packages/strapi-tiptap-editor/admin/src/components/Editor/TableMenuBar.tsx
@@ -95,7 +95,7 @@ export const TableMenuBar = ({ editor }: { editor: EditorTypes }) => {
                 defaultMessage: 'Row',
               })}
             </FormLabel>
-            <Select id="tableRow" onChange={onTableMenubarChange}>
+            <Select id="tableRow" onChange={onTableMenubarChange} value="">
               <SelectOption>
                 {formatMessage({
                   id: getTrad('components.tableMenuBar.select.placeholder'),
@@ -131,7 +131,7 @@ export const TableMenuBar = ({ editor }: { editor: EditorTypes }) => {
                 defaultMessage: 'Column',
               })}
             </FormLabel>
-            <Select id="tableColumn" onChange={onTableMenubarChange}>
+            <Select id="tableColumn" onChange={onTableMenubarChange} value="">
               <SelectOption>
                 {formatMessage({
                   id: getTrad('components.tableMenuBar.select.placeholder'),
@@ -167,7 +167,7 @@ export const TableMenuBar = ({ editor }: { editor: EditorTypes }) => {
                 defaultMessage: 'Header',
               })}
             </FormLabel>
-            <Select id="toggleHeader" onChange={onTableMenubarChange}>
+            <Select id="toggleHeader" onChange={onTableMenubarChange} value="">
               <SelectOption>
                 {formatMessage({
                   id: getTrad('components.tableMenuBar.select.placeholder'),
@@ -203,7 +203,7 @@ export const TableMenuBar = ({ editor }: { editor: EditorTypes }) => {
                 defaultMessage: 'Cell',
               })}
             </FormLabel>
-            <Select id="tableCell" onChange={onTableMenubarChange}>
+            <Select id="tableCell" onChange={onTableMenubarChange} value="">
               <SelectOption>
                 {formatMessage({
                   id: getTrad('components.tableMenuBar.select.placeholder'),

--- a/packages/strapi-tiptap-editor/admin/src/components/Editor/styles.ts
+++ b/packages/strapi-tiptap-editor/admin/src/components/Editor/styles.ts
@@ -40,6 +40,10 @@ export default styled(Box)`
     }
   }
 
+  .tippy-box {
+    background: transparent;
+  }
+
   .ProseMirror {
     outline: none;
     line-height: 1.25rem;


### PR DESCRIPTION
Issue Description:

- When you highlight text inside the table, the menubar popup appears.
- If you choose an option to modify the table, for example, ROW => insert row below, it works the first time but doesn't work when you try to add more rows.