### PR TITLE
chore(stylelint): fix deprecated rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -143,6 +143,7 @@
     "string-quotes": null,
     "property-no-vendor-prefix": null,
     "value-keyword-case": ["lower", { "camelCaseSvgKeywords": true }],
-    "declaration-block-no-redundant-longhand-properties": null
+    "declaration-block-no-redundant-longhand-properties": null,
+    "scss/at-import-no-partial-leading-underscore": null
   }
 }


### PR DESCRIPTION
Fixed stylelint warning:

> Deprecation warnings:
>  - The "scss/at-import-no-partial-leading-underscore" rule is deprecated.
>  - 'at-import-no-partial-leading-underscore' has been deprecated, and will be removed in '6.0'. Use 'load-no-partial-leading-underscore' instead. See: https://github.com/stylelint-scss/stylelint-scss/blob/v5.2.1/src/rules/at-import-no-partial-leading-underscore/README.md