### PR TITLE
feat: support form page refresh

### DIFF
--- a/apps/pdc-frontend/src/app/[locale]/(openFormsLayout)/form/[...slug]/page.tsx
+++ b/apps/pdc-frontend/src/app/[locale]/(openFormsLayout)/form/[...slug]/page.tsx
@@ -9,11 +9,16 @@ import { createOpenFormsApiUrl, createOpenFormsCssUrl, createOpenFormsSdkUrl } f
 type FormPageProps = {
   params: {
     locale: string;
-    slug: string;
+    slug: [formId: string, formStep: string];
   };
 };
 
-const FormPage = async ({ params: { locale, slug } }: FormPageProps) => {
+const FormPage = async ({
+  params: {
+    locale,
+    slug: [formId],
+  },
+}: FormPageProps) => {
   const { t } = await useTranslation(locale, 'common');
   const nonce = headers().get('x-nonce') || '';
 
@@ -44,8 +49,8 @@ const FormPage = async ({ params: { locale, slug } }: FormPageProps) => {
         sdkUrl={createOpenFormsSdkUrl()?.href || ''}
         cssUrl={createOpenFormsCssUrl()?.href || ''}
         nonce={nonce}
-        basePath={`/${locale}/form/${slug}/`}
-        slug={slug}
+        basePath={`/${locale}/form/${formId}/`}
+        slug={formId}
       />
       <Grid justifyContent="space-between" spacing="sm">
         <GridCell sm={8}>


### PR DESCRIPTION
closes 
- #416 

Implements the [catch-all route segment feature](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#catch-all-segments) for the form route. Effectively this allows us to catch anything after `/form/..`, for example: `/form/form-id/form-step` and make sure we only pass the `form-id` route segment to the OpenFormsSDK. 

This leaves the SDK free to interpret which step to load from the remainder of the URL, which means we can refresh the form embed page without losing the form or step 🚀