### PR TITLE
Added default message to aria-label in Gemeente utrecht logo

### DIFF
--- a/apps/pdc-frontend/src/app/[locale]/(openFormsLayout)/layout.tsx
+++ b/apps/pdc-frontend/src/app/[locale]/(openFormsLayout)/layout.tsx
@@ -180,7 +180,11 @@ const RootLayout = async ({ children, params: { locale } }: LayoutProps) => {
                         href={`/${locale}`}
                         className="utrecht-link utrecht-link--html-a utrecht-link--box-content"
                         prefetch={false}
-                        aria-label={t('logo.aria-label') || ''}
+                        aria-label={
+                          t('logo.aria-label', {
+                            defaultValue: 'Gemeente Utrecht logo, ga naar homepagina',
+                          }) || ''
+                        }
                       >
                         <Logo>
                           <LogoImage />

--- a/apps/pdc-frontend/src/app/[locale]/(rootLayout)/layout.tsx
+++ b/apps/pdc-frontend/src/app/[locale]/(rootLayout)/layout.tsx
@@ -162,7 +162,11 @@ const RootLayout = async ({ children, params: { locale } }: LayoutProps) => {
                         href={`/${locale}`}
                         className="utrecht-link utrecht-link--html-a utrecht-link--box-content"
                         prefetch={false}
-                        aria-label={t('logo.aria-label') || ''}
+                        aria-label={
+                          t('logo.aria-label', {
+                            defaultValue: 'Gemeente Utrecht logo, ga naar homepagina',
+                          }) || ''
+                        }
                       >
                         <Logo>
                           <LogoImage />

--- a/apps/vth-frontend/src/app/[locale]/layout.tsx
+++ b/apps/vth-frontend/src/app/[locale]/layout.tsx
@@ -173,7 +173,11 @@ const RootLayout = async ({ children, params: { locale } }: LayoutProps) => {
                       href={`/${locale}`}
                       className="utrecht-link utrecht-link--html-a utrecht-link--box-content utrecht-logo__wrapper"
                       prefetch={true}
-                      aria-label={t('logo.aria-label') || ''}
+                      aria-label={
+                        t('logo.aria-label', {
+                          defaultValue: 'Gemeente Utrecht logo, ga naar homepagina',
+                        }) || ''
+                      }
                     >
                       <Logo>
                         <LogoImage />


### PR DESCRIPTION
De default message zorgt ervoor dat zelfs als er geen aria-label message uit de json gehaald kan worden, er wel een valide aria-label op de logo is.