### PR TITLE
Fix the price widget issue

### DIFF
--- a/apps/pdc-frontend/src/components/Markdown/index.tsx
+++ b/apps/pdc-frontend/src/components/Markdown/index.tsx
@@ -4,7 +4,7 @@ import { Link } from '@utrecht/component-library-react';
 import isAbsoluteUrl from 'is-absolute-url';
 import Image from 'next/image';
 import NextLink from 'next/link';
-import type { ExtraProps } from 'react-markdown';
+import type { Options } from 'react-markdown';
 import { useTranslation } from '../../app/i18n/client';
 import { fallbackLng } from '../../app/i18n/settings';
 
@@ -35,8 +35,8 @@ export const Markdown = ({
   priceData?: PriceTypes[];
   locale?: string;
 }) => {
-  const priceWidget = {
-    span: ({ node }: ExtraProps) => {
+  const priceWidget: Options['components'] = {
+    span: ({ node, children: spanChildren }) => {
       if (node?.properties.dataStrapiCategory === 'price') {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const { t } = useTranslation(locale || fallbackLng, ['common']);
@@ -50,7 +50,7 @@ export const Markdown = ({
         );
       }
       delete node?.properties?.style;
-      return <span {...node?.properties}>{children}</span>;
+      return <span {...node?.properties}>{spanChildren}</span>;
     },
   };
 

--- a/packages/strapi-tiptap-editor/admin/src/components/extensions/Price/index.ts
+++ b/packages/strapi-tiptap-editor/admin/src/components/extensions/Price/index.ts
@@ -55,7 +55,11 @@ export const Price = Node.create({
       {
         tag: 'span',
         getAttrs: (element) => {
-          return (element as any).getAttribute('data-strapi-idref');
+          if ((element as any)?.hasAttribute('data-strapi-idref')) {
+            return (element as any).getAttribute('data-strapi-idref');
+          }
+
+          return false;
         },
       },
     ];


### PR DESCRIPTION
**Issue Description on Strapi:**

- The price widget renders a <span> tag when the copied text lacks any tag.
- Normal paragraphs contain an additional <span> tag as a child.

**Frontend Issue Status:**  Resolved

References:

- Test the editor functionality using this [page](https://pki.utrecht.nl/Loket/product/e15b8cd248f087798de40181b04132bd).
- Consult the TipTap editor [documentation](https://tiptap.dev/docs/editor/guide/custom-extensions#parse-html) for further assistance.