### PR TITLE
fix: click outside hook overriding default

### DIFF
--- a/packages/ui/src/hooks/useClickOutside.ts
+++ b/packages/ui/src/hooks/useClickOutside.ts
@@ -5,7 +5,6 @@ export const useClickOutside = (
   prevFocusableElement?: RefObject<HTMLButtonElement>,
 ) => {
   const handleClickOutside = (event: any) => {
-    event.preventDefault();
     if (ref.current && ref.current === event.target) {
       ref.current.close();
       if (prevFocusableElement) {


### PR DESCRIPTION
The `preventDefault()` here overrides every click event and prevents selection of text. I couldn't find any reason to prevent default here. It seems we can safely remove this and keep the drawer clickOutside functionality working.