### PR TITLE
fix: upl field in samenwerkende catalogi

### DIFF
--- a/apps/pdc-dashboard/src/components/components/cim-pdc-product-metadata.json
+++ b/apps/pdc-dashboard/src/components/components/cim-pdc-product-metadata.json
@@ -1,14 +1,13 @@
 {
   "collectionName": "components_components_cim_pdc_product_metadata",
   "info": {
-    "displayName": "CimPDC Product metadata",
+    "displayName": "Product metadata",
     "description": ""
   },
   "options": {},
   "attributes": {
     "productCode": {
       "type": "string",
-      "required": true,
       "unique": true
     },
     "beoogdResultaat": {
@@ -24,8 +23,7 @@
       "type": "string"
     },
     "uitvoeringsorganisatie": {
-      "type": "string",
-      "required": true
+      "type": "string"
     },
     "grondslag": {
       "type": "string"
@@ -34,22 +32,19 @@
       "type": "string"
     },
     "eigenaar": {
-      "type": "string",
-      "required": true
+      "type": "string"
     },
     "doelgroep": {
       "type": "enumeration",
-      "enum": ["gemeente\t", "provincie\t", "rijksoverheid\t", "waterschap"],
-      "required": true
+      "enum": ["bedrijven en instellingen", "burgers", "samenwerkingspartners", "interne organisatie"]
     },
     "bestelwijze": {
       "type": "enumeration",
-      "enum": ["informatie\t", "initiatief bevoegd gezag\t", "op verzoek"],
-      "required": true
+      "enum": ["informatie", "initiatief bevoegd gezag", "op verzoek"]
     },
     "soortBevoegdGezag": {
       "type": "enumeration",
-      "enum": ["gemeente\t", "provincie\t", "rijksoverheid\t", "waterschap"]
+      "enum": ["gemeente", "provincie", "rijksoverheid", "waterschap"]
     },
     "uplProductNaam": {
       "type": "customField",
@@ -60,7 +55,6 @@
       "type": "component",
       "repeatable": true,
       "component": "components.cim-pdc-product-beschrijving",
-      "required": true,
       "min": 1
     }
   }

--- a/apps/pdc-frontend/gql/graphql.ts
+++ b/apps/pdc-frontend/gql/graphql.ts
@@ -80,7 +80,6 @@ export type ComponentComponentsCatalogiMeta = {
   id: Scalars['ID']['output'];
   onlineRequest: ComponentComponentsOnlineRequest;
   spatial: ComponentComponentsSpatial;
-  uniformProductName?: Maybe<Scalars['String']['output']>;
 };
 
 
@@ -99,7 +98,6 @@ export type ComponentComponentsCatalogiMetaFiltersInput = {
   onlineRequest?: InputMaybe<ComponentComponentsOnlineRequestFiltersInput>;
   or?: InputMaybe<Array<InputMaybe<ComponentComponentsCatalogiMetaFiltersInput>>>;
   spatial?: InputMaybe<ComponentComponentsSpatialFiltersInput>;
-  uniformProductName?: InputMaybe<StringFilterInput>;
 };
 
 export type ComponentComponentsCatalogiMetaInput = {
@@ -109,7 +107,6 @@ export type ComponentComponentsCatalogiMetaInput = {
   id?: InputMaybe<Scalars['ID']['input']>;
   onlineRequest?: InputMaybe<ComponentComponentsOnlineRequestInput>;
   spatial?: InputMaybe<ComponentComponentsSpatialInput>;
-  uniformProductName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ComponentComponentsCimPdcProductAspectBeschrijving = {
@@ -174,17 +171,17 @@ export type ComponentComponentsCimPdcProductMetadata = {
   __typename?: 'ComponentComponentsCimPdcProductMetadata';
   afnemer?: Maybe<Scalars['String']['output']>;
   beoogdResultaat?: Maybe<Scalars['String']['output']>;
-  bestelwijze: Enum_Componentcomponentscimpdcproductmetadata_Bestelwijze;
-  cimPdcProductBeschrijving: Array<Maybe<ComponentComponentsCimPdcProductBeschrijving>>;
-  doelgroep: Enum_Componentcomponentscimpdcproductmetadata_Doelgroep;
-  eigenaar: Scalars['String']['output'];
+  bestelwijze?: Maybe<Enum_Componentcomponentscimpdcproductmetadata_Bestelwijze>;
+  cimPdcProductBeschrijving?: Maybe<Array<Maybe<ComponentComponentsCimPdcProductBeschrijving>>>;
+  doelgroep?: Maybe<Enum_Componentcomponentscimpdcproductmetadata_Doelgroep>;
+  eigenaar?: Maybe<Scalars['String']['output']>;
   grondslag?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  productCode: Scalars['String']['output'];
+  productCode?: Maybe<Scalars['String']['output']>;
   servicetermijn?: Maybe<Scalars['String']['output']>;
   soortBevoegdGezag?: Maybe<Enum_Componentcomponentscimpdcproductmetadata_Soortbevoegdgezag>;
   soortTaak?: Maybe<Scalars['String']['output']>;
-  uitvoeringsorganisatie: Scalars['String']['output'];
+  uitvoeringsorganisatie?: Maybe<Scalars['String']['output']>;
   uplProductNaam?: Maybe<Scalars['String']['output']>;
   wettelijkeTermijn?: Maybe<Scalars['String']['output']>;
 };
@@ -569,6 +566,7 @@ export type ComponentComponentsUtrechtRichText = {
   __typename?: 'ComponentComponentsUtrechtRichText';
   content: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  kennisartikelCategorie?: Maybe<Enum_Componentcomponentsutrechtrichtext_Kennisartikelcategorie>;
 };
 
 export type ComponentComponentsUtrechtSocialMediaLink = {
@@ -734,10 +732,10 @@ export enum Enum_Componentcomponentscimpdcproductmetadata_Bestelwijze {
 }
 
 export enum Enum_Componentcomponentscimpdcproductmetadata_Doelgroep {
-  Gemeente = 'gemeente',
-  Provincie = 'provincie',
-  Rijksoverheid = 'rijksoverheid',
-  Waterschap = 'waterschap'
+  BedrijvenEnInstellingen = 'bedrijven_en_instellingen',
+  Burgers = 'burgers',
+  InterneOrganisatie = 'interne_organisatie',
+  Samenwerkingspartners = 'samenwerkingspartners'
 }
 
 export enum Enum_Componentcomponentscimpdcproductmetadata_Soortbevoegdgezag {
@@ -788,6 +786,19 @@ export enum Enum_Componentcomponentsutrechtlogobutton_Logo {
   Eherkenning = 'eherkenning',
   Eidas = 'eidas',
   WithoutLogo = 'without_logo'
+}
+
+export enum Enum_Componentcomponentsutrechtrichtext_Kennisartikelcategorie {
+  Aanvraag = 'aanvraag',
+  Bewijs = 'bewijs',
+  Bezwaar = 'bezwaar',
+  Bijzonderheden = 'bijzonderheden',
+  Contact = 'contact',
+  Inleiding = 'inleiding',
+  Kosten = 'kosten',
+  Termijn = 'termijn',
+  Voorwaarden = 'voorwaarden',
+  WatTeDoenBijGeenReactie = 'wat_te_doen_bij_geen_reactie'
 }
 
 export enum Enum_Componentcomponentsutrechtsocialmedialink_Icon {

--- a/apps/pdc-sc/src/server.ts
+++ b/apps/pdc-sc/src/server.ts
@@ -20,7 +20,6 @@ const GET_SAMENWERKENDECATALOGI_FETCH = gql(`
           locale
           updatedAt
           catalogiMeta {
-            uniformProductName
             abstract
             spatial {
               scheme
@@ -37,6 +36,9 @@ const GET_SAMENWERKENDECATALOGI_FETCH = gql(`
             onlineRequest {
               type
             }
+          }
+          pdc_metadata {
+            uplProductNaam
           }
         }
       }

--- a/packages/samenwerkende-catalogi/src/index.ts
+++ b/packages/samenwerkende-catalogi/src/index.ts
@@ -36,8 +36,11 @@ type CatalogiMetaType = {
   authority: AuthorityType;
   audience: AudienceType[];
   onlineRequest: OnlineRequestType;
-  uniformProductName?: string;
   abstract: string;
+};
+
+type PdcMetaType = {
+  uplProductNaam?: string;
 };
 
 type AudienceType = {
@@ -48,6 +51,7 @@ type AudienceType = {
 
 type SamenWerkendeCatalogiAttributesTypes = {
   catalogiMeta: CatalogiMetaType;
+  pdc_metadata: PdcMetaType;
   locale: string;
   slug: string;
   title: string;
@@ -77,7 +81,7 @@ export const convertJsonToXML = (data: SamenWerkendeCatalogiDataType[], frontend
     const meta = data.map(({ attributes, id }) => {
       const gemeenteSpatial = attributes.catalogiMeta?.spatial.resourceIdentifier;
       const gemeenteAuthority = attributes.catalogiMeta?.authority.resourceIdentifier;
-      const uniformProductName = uplKeyValues.find(({ uri }) => uri === attributes.catalogiMeta?.uniformProductName);
+      const uniformProductName = uplKeyValues.find(({ uri }) => uri === attributes.pdc_metadata?.uplProductNaam);
       const prefLabelSpatial = getPrefLabel(gemeente.cv.value, attributes.catalogiMeta?.spatial.resourceIdentifier);
       const prefLabelAuthority = getPrefLabel(gemeente.cv.value, attributes.catalogiMeta?.authority.resourceIdentifier);
 


### PR DESCRIPTION
## Changes

- Updates query to get UPL from pdc_metadata
- Sets some (Cim)PDC Metadata fields to optional 
  - This needs to be done because the content editors are not familiar with all fields that are required in the CimPDC model. If we don't set those fields to optional, they won't be able to add a UPL. This is assuming that complete CimPDC metadata entry according to the model is less important (than the functionality of the the Samenwerkende Catalogi)
- Update codegen
- Update parsing code to use UPL field from metadata