### PR TITLE
fix: lead paragraph not rendering correctly

### DIFF
--- a/packages/strapi-tiptap-editor/admin/src/components/Editor/Toolbar.tsx
+++ b/packages/strapi-tiptap-editor/admin/src/components/Editor/Toolbar.tsx
@@ -52,6 +52,7 @@ interface ToolbarProps {
   toggleMediaLib: () => void;
   productPrice?: PriceListTypes;
 }
+
 interface LinkToolbarProps {
   editor: EditorTypes;
   onClick: (_event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -172,7 +173,7 @@ export const Toolbar = ({ editor, toggleMediaLib, settings, productPrice }: Tool
 
   if (editor.isActive('paragraph')) selectedTextStyle = 'paragraph';
 
-  if (editor.isActive('leadParagraph')) selectedTextStyle = 'leadParagraph';
+  if (editor.isActive('paragraph', { 'data-lead': true })) selectedTextStyle = 'leadParagraph';
 
   return (
     <div ref={observe} className={classnames({ sticky: !inView })}>

--- a/packages/strapi-tiptap-editor/admin/src/components/extensions/LeadParagraph/index.ts
+++ b/packages/strapi-tiptap-editor/admin/src/components/extensions/LeadParagraph/index.ts
@@ -1,5 +1,4 @@
-import { mergeAttributes } from '@tiptap/core';
-import Paragraph from '@tiptap/extension-paragraph';
+import { Paragraph } from '@tiptap/extension-paragraph';
 
 declare module '@tiptap/core' {
   // eslint-disable-next-line no-unused-vars
@@ -11,11 +10,19 @@ declare module '@tiptap/core' {
 }
 
 export const LeadParagraph = Paragraph.extend({
-  name: 'leadParagraph',
   addAttributes() {
     return {
       'data-lead': {
         default: true,
+        parseHTML: (element) => element.hasAttribute('data-lead'),
+        renderHTML: (attributes) => {
+          if (attributes['data-lead']) {
+            return {
+              'data-lead': attributes['data-lead'],
+            };
+          }
+          return {};
+        },
       },
     };
   },
@@ -24,11 +31,16 @@ export const LeadParagraph = Paragraph.extend({
       setLeadParagraph:
         () =>
         ({ commands }) => {
-          return commands.setNode(this.name);
+          return commands.setNode(this.name, { 'data-lead': true });
         },
     };
   },
-  renderHTML({ HTMLAttributes }) {
-    return ['p', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  parseHTML() {
+    return [
+      {
+        tag: 'p',
+        getAttrs: (element) => (element as any).getAttribute('data-lead'),
+      },
+    ];
   },
 });

--- a/packages/strapi-tiptap-editor/admin/src/components/extensions/LeadParagraph/index.ts
+++ b/packages/strapi-tiptap-editor/admin/src/components/extensions/LeadParagraph/index.ts
@@ -33,6 +33,11 @@ export const LeadParagraph = Paragraph.extend({
         ({ commands }) => {
           return commands.setNode(this.name, { 'data-lead': true });
         },
+      setParagraph:
+        () =>
+        ({ commands }) => {
+          return commands.setNode(this.name, { 'data-lead': false });
+        },
     };
   },
   parseHTML() {


### PR DESCRIPTION
closes 
- #568 

It's hard to figure out the optimal way to implement this through Tip Tap docs. As long as the end result is a paragraph with the correct `data-lead` attribute, and it can store and load that, we should be safe if we wish to implement this differently in the future. 