### PR TITLE
Details component addition

### DIFF
--- a/apps/vth-frontend/src/app/[locale]/[navigationPageSlug]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/[navigationPageSlug]/page.tsx
@@ -70,14 +70,30 @@ const NavigationPage = async ({ params: { locale, navigationPageSlug } }: Params
           ) : null;
         case 'ComponentComponentsUtrechtAccordion':
           return (
-            <AccordionProvider
-              sections={component.item.map(({ id, label, body }: any) => ({
-                id,
-                label,
-                headingLevel: 3,
-                body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
-              }))}
-            />
+            <div>
+              <h2>Details/Summary</h2>
+              <div>
+                {component.item.map(({ id, label, body }: any) => (
+                  <details key={id} className="utrecht-accordion">
+                    <summary className="utrecht-accordion__section">
+                      <h3 className="utrecht-button utrecht-button--subtle utrecht-accordion__button">{label}</h3>
+                    </summary>
+                    <div className="utrecht-accordion__panel">
+                      <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>
+                    </div>
+                  </details>
+                ))}
+              </div>
+              <h2>Original AccordionProvider</h2>
+              <AccordionProvider
+                sections={component.item.map(({ id, label, body }: any) => ({
+                  id,
+                  label,
+                  headingLevel: 3,
+                  body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
+                }))}
+              />
+            </div>
           );
         default:
           return null;

--- a/apps/vth-frontend/src/app/[locale]/article/[articleSlug]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/article/[articleSlug]/page.tsx
@@ -126,14 +126,30 @@ const ArticlePage = async ({ params: { locale, articleSlug } }: Params) => {
           ) : null;
         case 'ComponentComponentsUtrechtAccordion':
           return (
-            <AccordionProvider
-              sections={component.item.map(({ id, label, body }: any) => ({
-                id,
-                label,
-                headingLevel: 3,
-                body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
-              }))}
-            />
+            <div>
+              <h2>Details/Summary</h2>
+              <div>
+                {component.item.map(({ id, label, body }: any) => (
+                  <details key={id} className="utrecht-accordion">
+                    <summary className="utrecht-accordion__section">
+                      <h3 className="utrecht-button utrecht-button--subtle utrecht-accordion__button">{label}</h3>
+                    </summary>
+                    <div className="utrecht-accordion__panel">
+                      <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>
+                    </div>
+                  </details>
+                ))}
+              </div>
+              <h2>Original AccordionProvider</h2>
+              <AccordionProvider
+                sections={component.item.map(({ id, label, body }: any) => ({
+                  id,
+                  label,
+                  headingLevel: 3,
+                  body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
+                }))}
+              />
+            </div>
           );
         default:
           return null;

--- a/apps/vth-frontend/src/app/[locale]/print/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/print/page.tsx
@@ -180,15 +180,30 @@ const DynamicContent: React.FC<{
             ) : null;
           case 'ComponentComponentsUtrechtAccordion':
             return (
-              <AccordionProvider
-                key={index}
-                sections={component.item?.map(({ id, label, body }: any) => ({
-                  id,
-                  label,
-                  headingLevel: 3,
-                  body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
-                }))}
-              />
+              <div>
+                <h2>Details/Summary</h2>
+                <div>
+                  {component.item.map(({ id, label, body }: any) => (
+                    <details key={id} className="utrecht-accordion">
+                      <summary className="utrecht-accordion__section">
+                        <h3 className="utrecht-button utrecht-button--subtle utrecht-accordion__button">{label}</h3>
+                      </summary>
+                      <div className="utrecht-accordion__panel">
+                        <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>
+                      </div>
+                    </details>
+                  ))}
+                </div>
+                <h2>Original AccordionProvider</h2>
+                <AccordionProvider
+                  sections={component.item.map(({ id, label, body }: any) => ({
+                    id,
+                    label,
+                    headingLevel: 3,
+                    body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
+                  }))}
+                />
+              </div>
             );
           default:
             return null;

--- a/apps/vth-frontend/src/app/[locale]/theme/[themeSlug]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/theme/[themeSlug]/page.tsx
@@ -107,14 +107,16 @@ const ThemePage = async ({ params: { locale, themeSlug } }: Params) => {
           ) : null;
         case 'ComponentComponentsUtrechtAccordion':
           return (
-            <AccordionProvider
-              sections={component.item.map(({ id, label, body }: any) => ({
-                id,
-                label,
-                headingLevel: 3,
-                body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
-              }))}
-            />
+            <div>
+              {component.item.map(({ id, label, body }: any) => (
+                <details key={id}>
+                  <summary>{label}</summary>
+                  <div>
+                    <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>
+                  </div>
+                </details>
+              ))}
+            </div>
           );
         default:
           return null;

--- a/apps/vth-frontend/src/app/[locale]/theme/[themeSlug]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/theme/[themeSlug]/page.tsx
@@ -108,14 +108,27 @@ const ThemePage = async ({ params: { locale, themeSlug } }: Params) => {
         case 'ComponentComponentsUtrechtAccordion':
           return (
             <div>
-              {component.item.map(({ id, label, body }: any) => (
-                <details key={id}>
-                  <summary>{label}</summary>
-                  <div>
-                    <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>
-                  </div>
-                </details>
-              ))}
+              {' '}
+              <div>
+                {component.item.map(({ id, label, body }: any) => (
+                  <details key={id} className="utrecht-accordion">
+                    <summary className="utrecht-accordion__section">
+                      <h3 className="utrecht-button utrecht-button--subtle utrecht-accordion__button">{label}</h3>
+                    </summary>
+                    <div className="utrecht-accordion__panel">
+                      <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>
+                    </div>
+                  </details>
+                ))}
+              </div>
+              <AccordionProvider
+                sections={component.item.map(({ id, label, body }: any) => ({
+                  id,
+                  label,
+                  headingLevel: 3,
+                  body: <Markdown imageUrl={getImageBaseUrl()}>{body}</Markdown>,
+                }))}
+              />
             </div>
           );
         default:

--- a/apps/vth-frontend/src/app/[locale]/theme/[themeSlug]/page.tsx
+++ b/apps/vth-frontend/src/app/[locale]/theme/[themeSlug]/page.tsx
@@ -108,7 +108,7 @@ const ThemePage = async ({ params: { locale, themeSlug } }: Params) => {
         case 'ComponentComponentsUtrechtAccordion':
           return (
             <div>
-              {' '}
+              <h2>Details/Summary</h2>
               <div>
                 {component.item.map(({ id, label, body }: any) => (
                   <details key={id} className="utrecht-accordion">
@@ -121,6 +121,7 @@ const ThemePage = async ({ params: { locale, themeSlug } }: Params) => {
                   </details>
                 ))}
               </div>
+              <h2>Original AccordionProvider</h2>
               <AccordionProvider
                 sections={component.item.map(({ id, label, body }: any) => ({
                   id,

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -131,7 +131,7 @@ a {
 
 .utrecht-accordion__panel {
   background-attachment: local, local, scroll, scroll;
-  background-image: 
+  background-image:
     /* Shadows */
     linear-gradient(to right, white, white),
     linear-gradient(to right, white, white),
@@ -195,4 +195,40 @@ a {
     --utrecht-logo-wrapper-margin-block-end: 32px;
     --utrecht-navigation-toggle-button-padding-end: 32px;
   }
+}
+
+/* Experiment */
+details summary::-webkit-details-marker,
+details summary::marker {
+  display: none;
+  content: "";
+}
+
+h3.utrecht-accordion__button {
+  margin: 0px;
+}
+
+h3.utrecht-accordion__button::after {
+  display: block;
+  --utrecht-accordion-button-icon-background-color: #ffcc00;
+  --utrecht-accordion-button-icon-size: 24px;
+  background-image: var(
+    --utrecht-accordion-icon-arrow-up,
+    url(
+      data:image/svg + xml;charset=utf-8,
+      %3Csvgxmlns="http://www.w3.org/2000/svg"width="21.39"height="14.39"%3E%3Cpathfill="none"stroke="%231D1D1D"stroke-width="3"stroke-miterlimit="10"d="m15.866 4.135-5.32 5.322-5.322-5.322"/%3E%3C/svg%3E
+    )
+  );
+  background-position: 50%;
+  background-repeat: no-repeat;
+  content: "v";
+  text-align: center;
+  background-color: var(--utrecht-accordion-button-icon-background-color);
+  block-size: var(--utrecht-accordion-button-icon-size);
+  inline-size: var(--utrecht-accordion-button-icon-size);
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
 }

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -204,24 +204,21 @@ details summary::marker {
   content: "";
 }
 
-h3.utrecht-accordion__button {
+summary h3 {
   margin: 0px;
 }
 
-h3.utrecht-accordion__button::after {
+summary h3::after {
   display: block;
   --utrecht-accordion-button-icon-background-color: #ffcc00;
   --utrecht-accordion-button-icon-size: 24px;
   background-image: var(
-    --utrecht-accordion-icon-arrow-up,
-    url(
-      data:image/svg + xml;charset=utf-8,
-      %3Csvgxmlns="http://www.w3.org/2000/svg"width="21.39"height="14.39"%3E%3Cpathfill="none"stroke="%231D1D1D"stroke-width="3"stroke-miterlimit="10"d="m15.866 4.135-5.32 5.322-5.322-5.322"/%3E%3C/svg%3E
-    )
+    --utrecht-accordion-icon-arrow-down,
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='21.39' height='14.39'%3E%3Cpath fill='none' stroke='%231D1D1D' stroke-width='3' stroke-miterlimit='10' d='M15.866 4.135l-5.32 5.322-5.322-5.322'/%3E%3C/svg%3E")
   );
   background-position: 50%;
   background-repeat: no-repeat;
-  content: "v";
+  content: " ";
   text-align: center;
   background-color: var(--utrecht-accordion-button-icon-background-color);
   block-size: var(--utrecht-accordion-button-icon-size);
@@ -231,4 +228,11 @@ h3.utrecht-accordion__button::after {
   position: absolute;
   top: 0;
   right: 0;
+}
+
+details[open] summary h3::after {
+  background-image: var(
+    --utrecht-accordion-icon-arrow-up,
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='21.39' height='14.39'%3E%3Cpath fill='none' stroke='%231D1D1D' stroke-width='3' stroke-miterlimit='10' d='M5.223 9.457l5.32-5.322 5.322 5.322'/%3E%3C/svg%3E")
+  );
 }

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -130,14 +130,13 @@ a {
 }
 
 .utrecht-accordion__panel {
-  overflow: auto;
+  background-attachment: local, local, scroll, scroll;
   background-image: 
     /* Shadows */
     linear-gradient(to right, white, white),
     linear-gradient(to right, white, white),
-    /* Shadow covers */ linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0)),
-    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0));
-
+    /* Shadow covers */ linear-gradient(to right, rgba(0 0 0 / 25%), rgba(255 255 255 / 0%)),
+    linear-gradient(to left, rgba(0 0 0 / 25%), rgba(255 255 255 / 0%));
   background-position:
     left center,
     right center,
@@ -150,8 +149,7 @@ a {
     /* right */ 20px 100%,
     /* left */ 10px 100%,
     /* right */ 10px 100%;
-
-  background-attachment: local, local, scroll, scroll;
+  overflow: auto;
 }
 
 @media print {

--- a/apps/vth-frontend/src/styles/globals.css
+++ b/apps/vth-frontend/src/styles/globals.css
@@ -129,6 +129,31 @@ a {
   margin-inline: 1rem;
 }
 
+.utrecht-accordion__panel {
+  overflow: auto;
+  background-image: 
+    /* Shadows */
+    linear-gradient(to right, white, white),
+    linear-gradient(to right, white, white),
+    /* Shadow covers */ linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0)),
+    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0));
+
+  background-position:
+    left center,
+    right center,
+    left center,
+    right center;
+  background-repeat: no-repeat;
+  background-size:
+    /* left */
+    20px 100%,
+    /* right */ 20px 100%,
+    /* left */ 10px 100%,
+    /* right */ 10px 100%;
+
+  background-attachment: local, local, scroll, scroll;
+}
+
 @media print {
   .utrecht-accordion__panel {
     display: block;


### PR DESCRIPTION
Dit is een Proof of Concept van het gebruik van een Details component om een Accordion component te vervangen.

De Accordions van elk pagina van de VTH pagina is vervangen om het makkelijker te maken het verschil te zien.
Onder elk Detail component ligt een Accordion component om ze makkelijker te kunnen vergelijken.

Om dit zelf te testen, start VTH op en zorgt dat je op een pagina bent waar je een Uitklapper aan hebt toegevoegd in Strapi.
Er moet heel veel content in een Uitklapper panel, (de content moet langer zijn dan de hoogte van je scherm), zodat als je met je keyboard navigeert, je het verschil goed kan zien (probeer tussen de panels door te tabben en in elk panel de informatie door te lezen door het gebruik van de Down Arrow toets).

<img width="900" alt="Screenshot of webpage with an accordion and a details element" src="https://github.com/frameless/strapi/assets/11764984/ed9dfef1-0141-498f-a9af-f6263ccc7f16">
<img width="673" alt="Screenshot of the Strapi interface for adding accordions to a page" src="https://github.com/frameless/strapi/assets/11764984/7754f388-ec5b-4930-92d9-8b6408bd50a0">


