### PR TITLE
chore(pdc-frontend): fix docker build on Github-Actions

### DIFF
--- a/apps/pdc-frontend/src/app/[locale]/sitemap.ts
+++ b/apps/pdc-frontend/src/app/[locale]/sitemap.ts
@@ -4,7 +4,7 @@ import { createStrapiURL } from '@/util/createStrapiURL';
 import { fetchData } from '@/util/fetchData';
 import { GetAllProductsSitemapQuery } from '../../../gql/graphql';
 
-const { origin } = new URL(process.env.FRONTEND_PUBLIC_URL || '');
+const { origin } = new URL(process.env.FRONTEND_PUBLIC_URL || 'http://localhost:3000');
 
 const generateStaticPagesPath = (paths: string[]) => {
   return paths.map((path) => ({


### PR DESCRIPTION
The problem happened because the FRONTEND_PUBLIC_URL  environment variable wasn't there during the build on GitHub, and the new URL doesn't allow empty string.