### PR TITLE
feat: use new open forms public api

### DIFF
--- a/packages/strapi-plugin-open-forms-embed/admin/src/components/CustomCombobox/index.tsx
+++ b/packages/strapi-plugin-open-forms-embed/admin/src/components/CustomCombobox/index.tsx
@@ -39,7 +39,7 @@ function CustomCombobox({
   const [isLoading, setIsLoading] = useState(false);
 
   const { config } = usePluginConfig();
-  const apiUrl = config?.api_url?.endsWith('/') ? `${config?.api_url}forms` : `${config?.api_url}/forms`;
+  const apiUrl = config?.api_url?.endsWith('/') ? `${config?.api_url}public/forms` : `${config?.api_url}/public/forms`;
   const fetchAllOpenForms = async () => {
     setIsLoading(true);
     try {
@@ -51,8 +51,8 @@ function CustomCombobox({
           Authorization: `Token ${config.token}`,
         },
       });
-      const data = await response.json();
-      setOpenForms(data);
+      const { results } = await response.json();
+      setOpenForms(results);
       setIsLoading(false);
     } catch (error) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Closes #579 

Uses a faster API endpoint that exposes less data. [Swagger reference](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/2.6.0/src/openapi.yaml#/). 

## Todo
- [x] Test new endpoint (make sure you use Open Forms 2.6.x locally to test)