### PR TITLE
Fix/searchbar and tips page

### DIFF
--- a/apps/pdc-frontend/src/app/[locale]/(rootLayout)/search/[query]/page.tsx
+++ b/apps/pdc-frontend/src/app/[locale]/(rootLayout)/search/[query]/page.tsx
@@ -65,7 +65,7 @@ const Search = async ({ params: { locale, query } }: SearchProps) => {
   const searchResults = await getSuggestedSearch(locale, decodeQuery);
 
   if (searchResults && searchResults.hits && searchResults.hits.length === 0) {
-    redirect(`/search/tips/${decodeQuery}`);
+    redirect(`/search/tips?query=${decodeQuery}`);
   }
 
   const results =

--- a/apps/pdc-frontend/src/app/[locale]/(rootLayout)/search/tips/page.tsx
+++ b/apps/pdc-frontend/src/app/[locale]/(rootLayout)/search/tips/page.tsx
@@ -22,8 +22,9 @@ export async function generateMetadata({ params: { locale, query } }: Params): P
   };
 }
 
-const SearchTips = async ({ params: { locale, query } }: any) => {
+const SearchTips = async ({ params: { locale }, searchParams }: any) => {
   const { t } = await useTranslation(locale, ['tips-page', 'common']);
+  const query = searchParams?.query;
   const tipsList = t('body.section.unordered-list', { returnObjects: true }) as string[];
   const decodeQuery = decodeURIComponent(query);
   return (

--- a/apps/pdc-frontend/src/app/actions/index.ts
+++ b/apps/pdc-frontend/src/app/actions/index.ts
@@ -49,9 +49,10 @@ export const getSuggestedSearch = async (
 export const onSearchSubmitAction = async (formData: FormData, locale: string) => {
   const value = formData.get('search') as string;
   const result = await getSuggestedSearch(value, locale);
-  if (result?.total) {
+  if (result?.total && value.trim()) {
     redirect(`/${locale}/search/${value}`);
   }
+  redirect(`/${locale}/search/tips?query=`);
 };
 
 export const getLiveSuggestions = async (value: string) => {

--- a/apps/pdc-frontend/src/components/SearchBar/index.tsx
+++ b/apps/pdc-frontend/src/components/SearchBar/index.tsx
@@ -82,7 +82,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({
         input={{
           id: 'search-input',
           name: 'search',
-          required: true,
         }}
         itemToString={itemToString}
         renderOptions={(option) => {


### PR DESCRIPTION
### Fixed Issue #703 
Now the Required is removed so you can search with an empty search bar without a "fill out this field"
When you do search an empty string you get the same behaviour as [www.utrecht.nl ](www.utrecht.nl)


removed query from searchtips and added searchParams

![image](https://github.com/frameless/strapi/assets/100311542/24f119d9-9358-4004-8328-8234503f252a)
