### PR TITLE
fix: gebruik "Zoeken" label van button ook voor textbox

### DIFF
--- a/apps/pdc-frontend/src/components/UtrechtSearchBar/index.tsx
+++ b/apps/pdc-frontend/src/components/UtrechtSearchBar/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 import clsx from 'clsx';
 import Downshift, { DownshiftProps } from 'downshift';
-import React from 'react';
+import React, { useId } from 'react';
 import { Button, Textbox, UnorderedList, UnorderedListItem } from '@/components';
 
 type InputTypes = {
@@ -115,6 +115,7 @@ export const UtrechtSearchBar: React.FC<SearchBarProps> = ({
   renderOptions,
   ...rest
 }) => {
+  const buttonId = useId();
   return (
     <Downshift itemToString={itemToString} {...rest}>
       {({ getInputProps, getItemProps, isOpen, selectedItem, highlightedIndex, getMenuProps }) => (
@@ -127,11 +128,16 @@ export const UtrechtSearchBar: React.FC<SearchBarProps> = ({
               id={input?.id}
               name={input?.name}
               type="search"
-              aria-label={input?.ariaLabel}
+              aria-labelledby={buttonId}
               spellCheck={input?.spellCheck || false}
               className={clsx('utrecht-search-bar__input')}
             />
-            <Button type="submit" appearance="primary-action-button" className={clsx('utrecht-search-bar__button')}>
+            <Button
+              type="submit"
+              appearance="primary-action-button"
+              className={clsx('utrecht-search-bar__button')}
+              id={buttonId}
+            >
               {button.label}
             </Button>
           </div>


### PR DESCRIPTION
De tekstinvoer heeft op dit moment geen toegankelijk label:

<img width="295" alt="Screenshot 2024-07-02 at 22 38 48" src="https://github.com/frameless/strapi/assets/30694/1b6e9332-c098-4998-bf44-6fbc6d586d43">

Deze PR fixt dat, zonder dat er extra vertalingen nodig zijn.

<img width="313" alt="Screenshot 2024-07-02 at 22 39 01" src="https://github.com/frameless/strapi/assets/30694/531354a9-e7b4-41df-b950-0374c05a631c">
