### PR TITLE
fix: cleaner page footer link list rendering

### DIFF
--- a/packages/ui/src/components/Footer/index.module.scss
+++ b/packages/ui/src/components/Footer/index.module.scss
@@ -2,13 +2,18 @@
   --utrecht-link-list-icon-size: var(--utrecht-footer-link-social-media-list-icon-size, 24px);
 }
 .utrecht-footer {
-  --utrecht-link-list-icon-size: var(--utrecht-footer-link-list-icon-size);
+  --utrecht-heading-2-font-size: 24px;
+  --utrecht-heading-2-margin-block-start: 0;
+  --utrecht-heading-3-font-weight: 700;
   --utrecht-link-list-icon-inset-block-start: var(--utrecht-footer-link-list-icon-inset-block-start, 0.2em);
+  --utrecht-link-list-icon-size: var(--utrecht-footer-link-list-icon-size);
+  --utrecht-link-list-link-font-weight: 400;
+  --utrecht-link-list-margin-block-end: 0;
+  --utrecht-link-list-margin-block-start: 0;
+  --utrecht-link-list-row-gap: 16px;
   --utrecht-link-social-border-color: transparent;
-  --utrecht-link-list-margin-block-start: var(--utrecht-footer-link-list-margin-block-start, 24px);
-  --utrecht-page-footer-padding-inline-start: 0;
   --utrecht-page-footer-padding-inline-end: 0;
-  --utrecht-link-list-item-margin-block-start: var(--utrecht-link-list-item-margin-block-end, 16px);
+  --utrecht-page-footer-padding-inline-start: 0;
 }
 
 .utrecht-footer__list-title {

--- a/packages/ui/src/components/Footer/index.tsx
+++ b/packages/ui/src/components/Footer/index.tsx
@@ -73,37 +73,36 @@ export const Footer = ({ data, headingLevel, socialMediaLabel }: FooterProps) =>
             <Grid>
               <GridCell md={12}>{data?.title && <Heading2>{data?.title}</Heading2>}</GridCell>
               <GridCell md={6} sm={6}>
-                <ul className={css('utrecht-link-list', 'utrecht-link-list--html-ul')}>
-                  {data?.list &&
-                    data.list?.listItem?.length > 0 &&
-                    data?.list?.listItem?.map((item, index) => (
-                      <li key={index} className={css('utrecht-link-list__item')}>
-                        {item?.title && (
+                {data?.list &&
+                  data.list?.listItem?.length > 0 &&
+                  data?.list?.listItem?.map((item) => {
+                    return (
+                      <>
+                        {item?.title && item?.title && (
                           <Heading3 className={css('utrecht-footer__list-title')}>{item?.title}</Heading3>
                         )}
-                        <Grid flexDirection="column" spacing="sm">
-                          {item?.link &&
-                            item?.link?.length > 0 &&
-                            item?.link?.map((item, index) => {
+                        {Array.isArray(item.link) && item.link.length >= 1 && (
+                          <LinkList>
+                            {item?.link?.map((item, index) => {
                               const isPhoneNumber = item.href.includes('tel:14030');
                               return (
-                                <GridCell key={index} sm={12}>
-                                  <LinkListLink
-                                    icon={!isPhoneNumber && <UtrechtIconChevronRight />}
-                                    className={css('utrecht-link-list__link', {
-                                      'utrecht-link-list__link--phone': isPhoneNumber,
-                                    })}
-                                    href={item.href}
-                                  >
-                                    {item.textContent}
-                                  </LinkListLink>
-                                </GridCell>
+                                <LinkListLink
+                                  key={index}
+                                  icon={!isPhoneNumber && <UtrechtIconChevronRight />}
+                                  className={css({
+                                    'utrecht-link-list__link--phone': isPhoneNumber,
+                                  })}
+                                  href={item.href}
+                                >
+                                  {item.textContent}
+                                </LinkListLink>
                               );
                             })}
-                        </Grid>
-                      </li>
-                    ))}
-                </ul>
+                          </LinkList>
+                        )}
+                      </>
+                    );
+                  })}
               </GridCell>
               <GridCell md={6} sm={6}>
                 {data?.address && <Markdown>{data?.address}</Markdown>}


### PR DESCRIPTION
Before:

<img width="1121" alt="Screenshot 2024-07-03 at 00 18 55" src="https://github.com/frameless/strapi/assets/30694/0c18a954-60c5-43f2-9811-6d84768486a0">

After:

<img width="1125" alt="Screenshot 2024-07-03 at 00 18 42" src="https://github.com/frameless/strapi/assets/30694/40282a91-c4c0-4311-9eef-1b67b707f29c">

Also, the `<li>` without an `<ul>` has been fixed.