### PR TITLE
ci: use GitHub classic token to publish Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.GH_CLASSIC_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@94f8f8c2eec4bc3f1d78c1755580779804cb87b2 #v6.0.1
         with:


### PR DESCRIPTION
> GitHub Packages only supports authentication using a personal access token (classic). For more information, see "Managing your personal access tokens."

source: [Working with the Container registry ➝ Authenticating to the Container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)