### PR TITLE
fix: show Heading 1 with form name while loading form

### DIFF
--- a/apps/pdc-frontend/src/app/[locale]/(openFormsLayout)/form/[...slug]/page.tsx
+++ b/apps/pdc-frontend/src/app/[locale]/(openFormsLayout)/form/[...slug]/page.tsx
@@ -2,7 +2,15 @@ import { headers } from 'next/headers';
 import Link from 'next/link';
 import React from 'react';
 import { useTranslation } from '@/app/i18n';
-import { AdvancedLink, Breadcrumbs, Grid, GridCell, ScrollToTopButton, UtrechtIconChevronUp } from '@/components';
+import {
+  AdvancedLink,
+  Breadcrumbs,
+  Grid,
+  GridCell,
+  Heading1,
+  ScrollToTopButton,
+  UtrechtIconChevronUp,
+} from '@/components';
 import { OpenFormsEmbed } from '@/components/OpenFormsEmbed/OpenFormsEmbed';
 import { openFormValidator } from '@/util';
 import { createOpenFormsApiUrl, createOpenFormsCssUrl, createOpenFormsSdkUrl } from '@/util/openFormsSettings';
@@ -22,7 +30,8 @@ const FormPage = async ({
 }: FormPageProps) => {
   const { t } = await useTranslation(locale, 'common');
   const nonce = headers().get('x-nonce') || '';
-  await openFormValidator({ formId });
+
+  const formInfo = await openFormValidator({ formId });
 
   return (
     <>
@@ -60,6 +69,7 @@ const FormPage = async ({
             nonce={nonce}
             basePath={`/${locale}/form/${formId}/`}
             slug={formId}
+            fallback={formInfo ? <Heading1>{formInfo.name}</Heading1> : null}
           />
         </div>
         <Grid justifyContent="space-between" spacing="sm">

--- a/apps/pdc-frontend/src/components/OpenFormsEmbed/OpenFormsEmbed.tsx
+++ b/apps/pdc-frontend/src/components/OpenFormsEmbed/OpenFormsEmbed.tsx
@@ -1,8 +1,6 @@
-'use client';
-
+import React, { type ReactNode, useId } from 'react';
+import { OpenFormsScript } from './OpenFormsScript';
 import '@open-formulieren/sdk/styles.css';
-import Script from 'next/script';
-import React, { useRef } from 'react';
 
 export type OpenFormsEmbedProps = {
   nonce: string;
@@ -11,26 +9,19 @@ export type OpenFormsEmbedProps = {
   apiUrl: string;
   sdkUrl: string;
   cssUrl: string;
+  fallback?: ReactNode;
 };
 
-export const OpenFormsEmbed = ({ nonce, basePath, slug, apiUrl, sdkUrl, cssUrl }: OpenFormsEmbedProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const onLoadOpenForms = () => {
-    if (!containerRef.current) {
-      return;
-    }
-
-    // @ts-ignore
-    const form = new window.OpenForms.OpenForm(containerRef.current, containerRef.current.dataset);
-    form.init();
-  };
+export const OpenFormsEmbed = ({ nonce, basePath, slug, apiUrl, sdkUrl, cssUrl, fallback }: OpenFormsEmbedProps) => {
+  const id = useId();
 
   return (
-    <div>
-      <div ref={containerRef} data-base-url={apiUrl} data-form-id={slug} data-base-path={basePath}></div>
+    <>
+      <div id={id} data-base-url={apiUrl} data-form-id={slug} data-base-path={basePath}>
+        {fallback}
+      </div>
       <link rel="stylesheet" nonce={nonce} href={cssUrl} />
-      <Script nonce={nonce} strategy={'afterInteractive'} src={sdkUrl} onLoad={onLoadOpenForms} />
-    </div>
+      <OpenFormsScript targetId={id} nonce={nonce} src={sdkUrl} />
+    </>
   );
 };

--- a/apps/pdc-frontend/src/components/OpenFormsEmbed/OpenFormsScript.tsx
+++ b/apps/pdc-frontend/src/components/OpenFormsEmbed/OpenFormsScript.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Script from 'next/script';
+import React, { useRef } from 'react';
+
+export type OpenFormsScriptProps = {
+  nonce: string;
+  src: string;
+  targetId: string;
+};
+
+interface OpenForm {
+  new (_targetNode: Node, _opts: Object): OpenForm;
+
+  init(): Promise<void>;
+}
+
+declare global {
+  // eslint-disable-next-line no-unused-vars
+  interface Window {
+    OpenForms: {
+      OpenForm: OpenForm;
+    };
+  }
+}
+
+export const OpenFormsScript = ({ targetId, nonce, src }: OpenFormsScriptProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const onLoadOpenForms = () => {
+    if (!ref.current) {
+      return;
+    }
+
+    // @ts-ignore
+    const target = ref.current.ownerDocument.getElementById(targetId);
+
+    if (target && window.OpenForms) {
+      const form = new window.OpenForms.OpenForm(target, target.dataset);
+      form.init();
+    }
+  };
+
+  return (
+    <>
+      <div ref={ref}></div>
+      <Script nonce={nonce} strategy="afterInteractive" src={src} onLoad={onLoadOpenForms} />
+    </>
+  );
+};


### PR DESCRIPTION
This fixes one of the last remaining accessibility issues detected by SiteImprove.

<img width="629" alt="Screenshot 2024-07-10 at 00 04 32" src="https://github.com/frameless/strapi/assets/30694/37d285ee-990c-41bc-8a04-1fac364dd5a6">

I refactored the OpenFormsEmbed component to support server side rendering of fallback content. I configured the Heading 1 with the form name as fallback content.