### PR TITLE
style: changed position of the breadcrumb navigation

### DIFF
--- a/.changeset/twelve-eagles-happen.md
+++ b/.changeset/twelve-eagles-happen.md
@@ -1,0 +1,5 @@
+---
+"@frameless/pdc-frontend": patch
+---
+
+De brood kruimel pad krijgt nu de goede positie volgens het figma design.

--- a/apps/pdc-frontend/src/styles/globals.css
+++ b/apps/pdc-frontend/src/styles/globals.css
@@ -141,9 +141,12 @@ a {
 .utrecht-custom-header {
   --utrecht-page-padding-inline-start: 0;
   --utrecht-page-padding-inline-end: 0;
+  --utrecht-page-header-padding-block-end: 0;
 }
 
 .utrecht-custom-page {
+  --utrecht-page-content-padding-block-start: 0;
+
   background-color: var(--utrecht-document-background-color);
   display: flex;
   flex-direction: column;
@@ -187,6 +190,10 @@ p:has(a[class="utrecht-skip-link utrecht-skip-link--visible-on-focus"]) {
 
 .utrecht-navigation--mobile:has(button[aria-expanded="false"]) {
   padding-inline-end: var(--utrecht-navigation-toggle-button-padding-end);
+}
+
+.utrecht-breadcrumb-nav {
+  margin-block-end: var(--utrecht-rich-text-stranger-margin-block-end);
 }
 
 @media screen and (width > 360px) {


### PR DESCRIPTION
dit is de change in de branch
![image](https://github.com/user-attachments/assets/024b1bf4-762c-4266-b66c-98b019b89ba5)

[dit](https://www.figma.com/design/J8GosPQdIRzYgXiwB79gks/Formulieren-prototypes-(openForms)?node-id=260-232916&node-type=CANVAS&t=64ZE05mPTX9xnIXs-0) is hoe het in het figma hoort te staan