### PR TITLE
feat: add roles for pdc-dashboard

### DIFF
--- a/.changeset/spotty-ravens-end.md
+++ b/.changeset/spotty-ravens-end.md
@@ -1,0 +1,5 @@
+---
+"@frameless/pdc-dashboard": minor
+---
+
+Voeg rollen met aangepaste rechten toe aan PDC dashboard

--- a/apps/pdc-dashboard/config/sync/admin-role.beheerder-m5uxzjc8.json
+++ b/apps/pdc-dashboard/config/sync/admin-role.beheerder-m5uxzjc8.json
@@ -1,0 +1,1092 @@
+{
+  "name": "Beheerder",
+  "code": "beheerder-m5uxzjc8",
+  "description": "Algemene beheerdersrechten.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::not-found-page.not-found-page",
+      "properties": {
+        "fields": ["title", "body"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::not-found-page.not-found-page",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::not-found-page.not-found-page",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::not-found-page.not-found-page",
+      "properties": {
+        "fields": ["title", "body"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::not-found-page.not-found-page",
+      "properties": {
+        "fields": ["title", "body"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-home-page.pdc-home-page",
+      "properties": {
+        "fields": ["components"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-home-page.pdc-home-page",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-home-page.pdc-home-page",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-home-page.pdc-home-page",
+      "properties": {
+        "fields": ["components"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-home-page.pdc-home-page",
+      "properties": {
+        "fields": ["components"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-template.pdc-template",
+      "properties": {
+        "fields": ["sections"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-template.pdc-template",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-template.pdc-template",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-template.pdc-template",
+      "properties": {
+        "fields": ["sections"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-template.pdc-template",
+      "properties": {
+        "fields": ["sections"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.access",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.regenerate",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::config-sync.menu-link",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::config-sync.settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.collection-types.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.components.configure-layout",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.single-types.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-type-builder.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::import-export-entries.export",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::import-export-entries.import",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.copy-link",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.download",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.email-templates.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.email-templates.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.providers.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.providers.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    }
+  ]
+}

--- a/apps/pdc-dashboard/config/sync/admin-role.kennisbank-lezer-m5uvxm3k.json
+++ b/apps/pdc-dashboard/config/sync/admin-role.kennisbank-lezer-m5uvxm3k.json
@@ -1,0 +1,51 @@
+{
+  "name": "Kennisbank Lezer ",
+  "code": "kennisbank-lezer-m5uvxm3k",
+  "description": "Alleen-lezen rechten op de Kennisbank, inclusief VAC en interne velden.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    }
+  ]
+}

--- a/apps/pdc-dashboard/config/sync/admin-role.kennisbank-schrijver-m5uxgzkp.json
+++ b/apps/pdc-dashboard/config/sync/admin-role.kennisbank-schrijver-m5uxgzkp.json
@@ -1,0 +1,181 @@
+{
+  "name": "Kennisbank Schrijver",
+  "code": "kennisbank-schrijver-m5uxgzkp",
+  "description": "Schrijfrechten voor de Kennisbank, inclusief VAC en interne velden.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::vac.vac",
+      "properties": {
+        "fields": [
+          "vac.vraag",
+          "vac.antwoord.content",
+          "vac.antwoord.kennisartikelCategorie",
+          "vac.status",
+          "vac.doelgroep",
+          "vac.afdelingen.afdelingId",
+          "vac.afdelingen.afdelingNaam",
+          "vac.uuid",
+          "vac.toelichting",
+          "vac.trefwoorden.trefwoord"
+        ]
+      },
+      "conditions": []
+    }
+  ]
+}

--- a/apps/pdc-dashboard/config/sync/admin-role.pdc-lezer-m5uuxokf.json
+++ b/apps/pdc-dashboard/config/sync/admin-role.pdc-lezer-m5uuxokf.json
@@ -1,0 +1,146 @@
+{
+  "name": "PDC Lezer",
+  "code": "pdc-lezer-m5uuxokf",
+  "description": "Alleen-lezen rechten op de PDC.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    }
+  ]
+}

--- a/apps/pdc-dashboard/config/sync/admin-role.pdc-schrijver-m5uxb98h.json
+++ b/apps/pdc-dashboard/config/sync/admin-role.pdc-schrijver-m5uxb98h.json
@@ -1,0 +1,486 @@
+{
+  "name": "PDC Schrijver",
+  "code": "pdc-schrijver-m5uxb98h",
+  "description": "Schrijfrechten voor de PDC.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::internal-field.internal-field",
+      "properties": {
+        "fields": [
+          "title",
+          "content.uuid",
+          "content.contentBlock.content",
+          "content.contentBlock.kennisartikelCategorie",
+          "product"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-category.pdc-category",
+      "properties": {
+        "fields": ["title", "pdc_subcategories"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-faq.pdc-faq",
+      "properties": {
+        "fields": ["title", "faq.label", "faq.body", "faq.headingLevel", "faq.kennisartikelCategorie"],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pdc-subcategory.pdc-subcategory",
+      "properties": {
+        "fields": ["title", "pdc_category", "products"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::price.price",
+      "properties": {
+        "fields": ["price.label", "price.currency", "price.value", "price.uuid", "title", "products", "uuid"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::product.product",
+      "properties": {
+        "fields": [
+          "title",
+          "content",
+          "sections",
+          "price",
+          "metaTags.keymatch",
+          "metaTags.title",
+          "metaTags.description",
+          "metaTags.ogImage",
+          "catalogiMeta.spatial.resourceIdentifier",
+          "catalogiMeta.spatial.scheme",
+          "catalogiMeta.authority.resourceIdentifier",
+          "catalogiMeta.authority.scheme",
+          "catalogiMeta.audience.type",
+          "catalogiMeta.onlineRequest.type",
+          "catalogiMeta.abstract",
+          "metadata.singleDigitalGateway",
+          "metadata.attachementAdded",
+          "metadata.contact.name",
+          "metadata.contact.email",
+          "metadata.eForm.linkedEForm",
+          "slug",
+          "pdc_subcategories",
+          "pdc_metadata.productCode",
+          "pdc_metadata.beoogdResultaat",
+          "pdc_metadata.wettelijkeTermijn",
+          "pdc_metadata.servicetermijn",
+          "pdc_metadata.afnemer",
+          "pdc_metadata.uitvoeringsorganisatie",
+          "pdc_metadata.grondslag",
+          "pdc_metadata.soortTaak",
+          "pdc_metadata.eigenaar",
+          "pdc_metadata.doelgroep",
+          "pdc_metadata.bestelwijze",
+          "pdc_metadata.soortBevoegdGezag",
+          "pdc_metadata.uplProductNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.taal",
+          "pdc_metadata.cimPdcProductBeschrijving.productNaam",
+          "pdc_metadata.cimPdcProductBeschrijving.omschrijving",
+          "pdc_metadata.cimPdcProductBeschrijving.trefwoord",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.onderwerp",
+          "pdc_metadata.cimPdcProductBeschrijving.cimPdcProductAspectBeschrijving.uitleg",
+          "productencatalogus",
+          "uuid",
+          "kennisartikelMetadata.doelgroep",
+          "kennisartikelMetadata.productAanwezig",
+          "kennisartikelMetadata.productValtOnder",
+          "kennisartikelMetadata.afdelingen.afdelingId",
+          "kennisartikelMetadata.afdelingen.afdelingNaam",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsIdentifier",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsPrefLabel",
+          "kennisartikelMetadata.verantwoordelijkeOrganisatie.owmsEndDate",
+          "kennisartikelMetadata.uuid",
+          "kennisartikelMetadata.upnUri"
+        ],
+        "locales": ["en", "nl"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::productencatalogus.productencatalogus",
+      "properties": {
+        "fields": [
+          "organisatieIdentificatie",
+          "domein",
+          "naam",
+          "toelichting",
+          "versie",
+          "begindatumVersie",
+          "beherendeOrganisatie",
+          "contactpersoonBeheerNaam",
+          "contactpersoonBeheerEmail",
+          "producten",
+          "referentiePDC",
+          "doelgroep",
+          "referentieCatalogus"
+        ]
+      },
+      "conditions": []
+    }
+  ]
+}


### PR DESCRIPTION
**Note**: There is a small issue when using only the PDC Lezer or Schrijver roles. The issue involves receiving an error message like the one below. 
<img width="543" alt="Screenshot 2025-01-13 at 13 22 15" src="https://github.com/user-attachments/assets/9c98c092-b3b3-4aac-b6d1-95dec4399808" />

This happens because of the internal field:

- The field has a two-way relationship with the product.
- The internal field is located in the dynamic-zone/sections, which means we cannot assign it to a role.

**The solution is**:

- PDC Lezer: Has view access to the internal field.
- PDC Schrijver: Can only view the internal field.

[Issue-991](https://github.com/frameless/strapi/issues/991) 
[issue-979](https://github.com/frameless/strapi/issues/979)