### PR TITLE
fix(pdc-dashboard): shorten component name to prevent database identifier length issues 

### DIFF
--- a/apps/pdc-dashboard/src/components/components/additional-information.json
+++ b/apps/pdc-dashboard/src/components/components/additional-information.json
@@ -1,5 +1,5 @@
 {
-  "collectionName": "components_components_additional_informations",
+  "collectionName": "additional_information",
   "info": {
     "displayName": "Additional information",
     "icon": "information",


### PR DESCRIPTION
### Shorten the component name to prevent database identifier length issues 

Renamed `components_components_additional_informations` to a shorter name to avoid database errors caused by exceeding identifier length limits. Fixes issues related to Strapi's database schema constraints.

https://github.com/strapi/strapi/issues/12101