### PR TITLE
fix: fix buildURL function

### DIFF
--- a/.changeset/lazy-phones-reply.md
+++ b/.changeset/lazy-phones-reply.md
@@ -1,0 +1,5 @@
+---
+"@frameless/pdc-frontend": patch
+---
+
+Fix voor een probleem waarbij sommige URL's onterecht als ongeldig werden beschouwd.

--- a/apps/pdc-frontend/src/util/buildURL.ts
+++ b/apps/pdc-frontend/src/util/buildURL.ts
@@ -101,8 +101,7 @@ export const buildURL = ({
       key,
       isOrigin,
     });
-
-    if (typeof url !== 'string' || !url.trim()) {
+    if (!url || (typeof url === 'string' && !url.trim())) {
       throw new Error(
         `Invalid URL: getURL returned an empty or invalid value ('${url}'). Ensure the environment variable '${key}' is correctly set and valid.`,
       );


### PR DESCRIPTION
if isOrigin is false, getURL returns a URL object instead of a string.