### PR TITLE
fix(pdc-frontend): disable flo-legal from graphql

### DIFF
--- a/apps/pdc-frontend/src/query/index.ts
+++ b/apps/pdc-frontend/src/query/index.ts
@@ -155,11 +155,11 @@ export const GET_PRODUCT_BY_SLUG = gql(`
             openFormsEmbed
             textContent
           }
-          ... on ComponentComponentsFloLegalForm {
-            __typename
-            id
-            floLegalFormSelector
-          }
+          # ... on ComponentComponentsFloLegalForm {
+          #   __typename
+          #   id
+          #   floLegalFormSelector
+          # }
           ... on ComponentComponentsUtrechtSpotlight {
             __typename
             content


### PR DESCRIPTION
We disabled the flo-legal query because it is no longer available after being disabled in Strapi.