### PR TITLE
fix(docker): resolve VTH frontend Docker build issues

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -30,9 +30,11 @@ RUN set -eux; yarn install --frozen-lockfile
 
 # --- Builder stage: Compile and build assets ---
 FROM build AS builder
+# Set build argument for Node.js memory limit
+ARG NODE_MAX_OLD_SPACE_SIZE=4096
 # Copy remaining files and build the application.
 COPY . /opt/app/
-RUN set -eux; yarn build
+RUN set -eux; NODE_OPTIONS="--max-old-space-size=${NODE_MAX_OLD_SPACE_SIZE}" yarn build
 
 # --- Production stage: Prepare a lean image for runtime ---
 FROM node:20-alpine3.18 AS production


### PR DESCRIPTION
Increase Node.js heap size to 4GB in production Dockerfile to prevent OOM during Next.js build