### PR TITLE
style: add block size navigation link mobile

### DIFF
--- a/.changeset/rotten-geese-impress.md
+++ b/.changeset/rotten-geese-impress.md
@@ -1,0 +1,13 @@
+---
+"@frameless/ui": patch
+---
+
+Added link min-block-size for consistency with Figma
+
+### Patch Changes
+
+Opgeloste UI-problemen in het menu:
+
+Menu mobiel versie ListItems/link block size volgens figma afmetingen
+
+([GitHub Issue Frameless/strapi#46](https://github.com/orgs/GemeenteUtrecht/projects/24/views/1?pane=issue&itemId=127187528&issue=GemeenteUtrecht%7Cdesignsystem.utrecht.nl%7C46))

--- a/packages/ui/src/components/Navigation/NavigationLink/index.module.scss
+++ b/packages/ui/src/components/Navigation/NavigationLink/index.module.scss
@@ -58,6 +58,7 @@
   --utrecht-navigation-link-justify-content: var(--utrecht-navigation-link-mobile-justify-content, flex-start);
 
   flex: 1 1 auto;
+  min-block-size: var(--utrecht-navigation-link-mobile-min-block-size, 44px);
   transition-duration: var(--utrecht-navigation-link-mobile-transition-duration, 0.3s);
   transition-property: font-weight;
   transition-timing-function: var(--utrecht-navigation-link-mobile-transition-timing-function, ease-in-out);


### PR DESCRIPTION
* https://github.com/orgs/GemeenteUtrecht/projects/24/views/1?pane=issue&itemId=127187528&issue=GemeenteUtrecht%7Cdesignsystem.utrecht.nl%7C46

- [x] Utrecht navigation List block size 44px volgens figma design

