### PR TITLE
fix: shorten contact information collection names for PostgreSQL

### DIFF
--- a/apps/pdc-dashboard/src/api/contact-information-internal/content-types/contact-information-internal/schema.json
+++ b/apps/pdc-dashboard/src/api/contact-information-internal/content-types/contact-information-internal/schema.json
@@ -1,6 +1,6 @@
 {
   "kind": "collectionType",
-  "collectionName": "contact_informations",
+  "collectionName": "contact_info_internal",
   "info": {
     "singularName": "contact-information-internal",
     "pluralName": "contact-information-internals",

--- a/apps/pdc-dashboard/src/api/contact-information-public/content-types/contact-information-public/schema.json
+++ b/apps/pdc-dashboard/src/api/contact-information-public/content-types/contact-information-public/schema.json
@@ -1,6 +1,6 @@
 {
   "kind": "collectionType",
-  "collectionName": "contact_information_public",
+  "collectionName": "contact_info_public",
   "info": {
     "singularName": "contact-information-public",
     "pluralName": "contact-information-publics",

--- a/apps/pdc-dashboard/src/components/components/contact-information-public.json
+++ b/apps/pdc-dashboard/src/components/components/contact-information-public.json
@@ -1,5 +1,5 @@
 {
-  "collectionName": "contact_information_public_component",
+  "collectionName": "contact_info_public_comp",
   "info": {
     "displayName": "Contact informatie (Openbaar)",
     "icon": "phone",

--- a/apps/pdc-dashboard/src/components/components/contact-information-rich-text.json
+++ b/apps/pdc-dashboard/src/components/components/contact-information-rich-text.json
@@ -1,5 +1,5 @@
 {
-  "collectionName": "contact-information_rich_text",
+  "collectionName": "contact_info_rich_text",
   "info": {
     "displayName": "Inhoud"
   },


### PR DESCRIPTION
Shortened collection names to avoid PostgreSQL's 63-character identifier limit:
- contact_information_public → contact_info_public
- contact_informations → contact_info_internal
- contact_information_public_component → contact_info_public_comp
- contact-information_rich_text → contact_info_rich_text

This fixes the "relation already exists" error when running with PostgreSQL in Docker. The issue only occurred with PostgreSQL due to its identifier length restrictions, while SQLite (used locally) has no such limit.