### PR TITLE
fix(database): patch slug migration to handle missing unique index on PostgreSQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
   "pnpm": {
     "overrides": {
       "eslint": "^9.39.3"
+    },
+    "patchedDependencies": {
+      "@strapi/database": "patches/@strapi__database.patch"
     }
   },
   "resolutions": {

--- a/patches/@strapi__database.patch
+++ b/patches/@strapi__database.patch
@@ -1,0 +1,182 @@
+diff --git a/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.js b/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.js
+index cc1b216e20e68d5152e641e9e92ef90b16e61e98..234154f412c5e8c8f65cfc19fc0e8e05f7325670 100644
+--- a/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.js
++++ b/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.js
+@@ -6,35 +6,75 @@
+  *
+  * This migration drops existing unique indexes from slug fields so downstream migrations
+  * can work on the data without violating the unique index.
+- */ const dropIndex = async (knex, tableName, columnName)=>{
++ *
++ * PATCH: Original caught JS errors but not PostgreSQL transaction-level abort state.
++ * In PostgreSQL, any failed statement inside a transaction marks the ENTIRE transaction
++ * as aborted, rejecting all subsequent commands including harmless hasTable() calls.
++ * Fix: Use SAVEPOINT / ROLLBACK TO SAVEPOINT to isolate each DROP INDEX attempt.
++ */
++
++const isPostgres = (knex) => {
++    const client = knex.client?.config?.client ?? '';
++    return client === 'pg' || client === 'postgres' || client === 'postgresql';
++};
++
++const dropIndex = async (knex, tableName, columnName) => {
++    const usesSavepoints = isPostgres(knex);
++
++    const savepointName = `sp_drop_${tableName}_${columnName}`
++        .replace(/[^a-z0-9_]/gi, '_')
++        .toLowerCase()
++        .slice(0, 63);
++
+     try {
+-        await knex.schema.alterTable(tableName, (table)=>{
++        if (usesSavepoints) {
++            await knex.raw(`SAVEPOINT ${savepointName}`);
++        }
++
++        await knex.schema.alterTable(tableName, (table) => {
+             // NOTE: Can not use "identifiers" utility, as the 5.0.0-01 migration does not rename this particular index
+             // to `tableName_columnName_uq`.
+-            table.dropUnique([
+-                columnName
+-            ], `${tableName}_${columnName}_unique`);
++            table.dropUnique([columnName], `${tableName}_${columnName}_unique`);
+         });
++
++        if (usesSavepoints) {
++            await knex.raw(`RELEASE SAVEPOINT ${savepointName}`);
++        }
+     } catch (error) {
+-    // If unique index does not exist, do nothing
++        if (usesSavepoints) {
++            try {
++                await knex.raw(`ROLLBACK TO SAVEPOINT ${savepointName}`);
++            } catch (_) {
++                // Savepoint may not exist if failure happened before it was created
++            }
++        }
++        // Index did not exist or already dropped — acceptable, move on
+     }
+ };
++
+ const dropSlugFieldsIndex = {
+     name: '5.0.0-05-drop-slug-fields-index',
+-    async up (knex, db) {
+-        for (const meta of db.metadata.values()){
+-            const hasTable = await knex.schema.hasTable(meta.tableName);
++    async up(knex, db) {
++        for (const meta of db.metadata.values()) {
++            let hasTable = false;
++            try {
++                hasTable = await knex.schema.hasTable(meta.tableName);
++            } catch (_error) {
++                continue;
++            }
++
+             if (!hasTable) {
+                 continue;
+             }
+-            for (const attribute of Object.values(meta.attributes)){
++
++            for (const attribute of Object.values(meta.attributes)) {
+                 if (attribute.type === 'uid' && attribute.columnName) {
+                     await dropIndex(knex, meta.tableName, attribute.columnName);
+                 }
+             }
+         }
+     },
+-    async down () {
++    async down() {
+         throw new Error('not implemented');
+     }
+ };
+diff --git a/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.mjs b/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.mjs
+index 75fe5257f065c59930b21761ff70de975604e488..90722a798d9bbc616c9d9f7b372cc57cfb67dbed 100644
+--- a/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.mjs
++++ b/dist/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.mjs
+@@ -4,35 +4,75 @@
+  *
+  * This migration drops existing unique indexes from slug fields so downstream migrations
+  * can work on the data without violating the unique index.
+- */ const dropIndex = async (knex, tableName, columnName)=>{
++ *
++ * PATCH: Original caught JS errors but not PostgreSQL transaction-level abort state.
++ * In PostgreSQL, any failed statement inside a transaction marks the ENTIRE transaction
++ * as aborted, rejecting all subsequent commands including harmless hasTable() calls.
++ * Fix: Use SAVEPOINT / ROLLBACK TO SAVEPOINT to isolate each DROP INDEX attempt.
++ */
++
++const isPostgres = (knex) => {
++    const client = knex.client?.config?.client ?? '';
++    return client === 'pg' || client === 'postgres' || client === 'postgresql';
++};
++
++const dropIndex = async (knex, tableName, columnName) => {
++    const usesSavepoints = isPostgres(knex);
++
++    const savepointName = `sp_drop_${tableName}_${columnName}`
++        .replace(/[^a-z0-9_]/gi, '_')
++        .toLowerCase()
++        .slice(0, 63);
++
+     try {
+-        await knex.schema.alterTable(tableName, (table)=>{
++        if (usesSavepoints) {
++            await knex.raw(`SAVEPOINT ${savepointName}`);
++        }
++
++        await knex.schema.alterTable(tableName, (table) => {
+             // NOTE: Can not use "identifiers" utility, as the 5.0.0-01 migration does not rename this particular index
+             // to `tableName_columnName_uq`.
+-            table.dropUnique([
+-                columnName
+-            ], `${tableName}_${columnName}_unique`);
++            table.dropUnique([columnName], `${tableName}_${columnName}_unique`);
+         });
++
++        if (usesSavepoints) {
++            await knex.raw(`RELEASE SAVEPOINT ${savepointName}`);
++        }
+     } catch (error) {
+-    // If unique index does not exist, do nothing
++        if (usesSavepoints) {
++            try {
++                await knex.raw(`ROLLBACK TO SAVEPOINT ${savepointName}`);
++            } catch (_) {
++                // Savepoint may not exist if failure happened before it was created
++            }
++        }
++        // Index did not exist or already dropped — acceptable, move on
+     }
+ };
++
+ const dropSlugFieldsIndex = {
+     name: '5.0.0-05-drop-slug-fields-index',
+-    async up (knex, db) {
+-        for (const meta of db.metadata.values()){
+-            const hasTable = await knex.schema.hasTable(meta.tableName);
++    async up(knex, db) {
++        for (const meta of db.metadata.values()) {
++            let hasTable = false;
++            try {
++                hasTable = await knex.schema.hasTable(meta.tableName);
++            } catch (_error) {
++                continue;
++            }
++
+             if (!hasTable) {
+                 continue;
+             }
+-            for (const attribute of Object.values(meta.attributes)){
++
++            for (const attribute of Object.values(meta.attributes)) {
+                 if (attribute.type === 'uid' && attribute.columnName) {
+                     await dropIndex(knex, meta.tableName, attribute.columnName);
+                 }
+             }
+         }
+     },
+-    async down () {
++    async down() {
+         throw new Error('not implemented');
+     }
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   '@types/minimatch': 5.1.2
   eslint: ^9.39.3
 
+patchedDependencies:
+  '@strapi/database':
+    hash: 9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c
+    path: patches/@strapi__database.patch
+
 importers:
 
   .:
@@ -753,7 +758,7 @@ importers:
         version: 13.5.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0)
       next-sitemap:
         specifier: 4.1.8
-        version: 4.1.8(next@13.5.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0))
+        version: 4.1.8(next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -27371,7 +27376,7 @@ snapshots:
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       '@strapi/admin': 5.39.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)(typescript@5.4.4))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.12))(@types/node@24.12.2)(@types/react-dom@18.3.1)(@types/react@18.3.12)(better-sqlite3@12.6.2)(codemirror@5.65.21)(debug@4.3.4)(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/content-manager': 5.39.0(532dc039496394ee889d4c975bf7e450)
-      '@strapi/database': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
+      '@strapi/database': 5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.1)(@types/react@18.3.12)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/types': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)(typescript@5.4.4)
@@ -27471,7 +27476,7 @@ snapshots:
       '@koa/router': 12.0.2
       '@paralleldrive/cuid2': 2.2.2
       '@strapi/admin': 5.39.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)(typescript@5.4.4))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.12))(@types/node@24.12.2)(@types/react-dom@18.3.1)(@types/react@18.3.12)(better-sqlite3@12.6.2)(codemirror@5.65.21)(debug@4.3.4)(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/database': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
+      '@strapi/database': 5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
       '@strapi/generators': 5.39.0(@babel/preset-env@7.24.8(@babel/core@7.29.0))(@types/node@24.12.2)
       '@strapi/logger': 5.39.0
       '@strapi/permissions': 5.39.0
@@ -27624,7 +27629,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@strapi/database@5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)':
+  '@strapi/database@5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)':
     dependencies:
       '@paralleldrive/cuid2': 2.2.2
       '@strapi/utils': 5.39.0
@@ -28114,7 +28119,7 @@ snapshots:
       '@strapi/content-type-builder': 5.39.0(7252308f3a95b69f400a5c7a9c8699c3)
       '@strapi/core': 5.39.0(@babel/preset-env@7.24.8(@babel/core@7.29.0))(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)(typescript@5.4.4))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.12))(@types/node@24.12.2)(@types/react-dom@18.3.1)(@types/react@18.3.12)(better-sqlite3@12.6.2)(codemirror@5.65.21)(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/data-transfer': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)(typescript@5.4.4)
-      '@strapi/database': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
+      '@strapi/database': 5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
       '@strapi/email': 5.39.0(1edcbd1ec5b19d7aecd8b446e1847eff)
       '@strapi/generators': 5.39.0(@babel/preset-env@7.24.8(@babel/core@7.29.0))(@types/node@24.12.2)
       '@strapi/i18n': 5.39.0(1e2d042201398a642bc787f762572152)
@@ -28231,7 +28236,7 @@ snapshots:
       '@casl/ability': 6.7.5
       '@koa/cors': 5.0.0
       '@koa/router': 12.0.2
-      '@strapi/database': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
+      '@strapi/database': 5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
       '@strapi/logger': 5.39.0
       '@strapi/permissions': 5.39.0
       '@strapi/utils': 5.39.0
@@ -28261,7 +28266,7 @@ snapshots:
       '@casl/ability': 6.7.5
       '@koa/cors': 5.0.0
       '@koa/router': 12.0.2
-      '@strapi/database': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
+      '@strapi/database': 5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
       '@strapi/logger': 5.39.0
       '@strapi/permissions': 5.39.0
       '@strapi/utils': 5.39.0
@@ -28331,7 +28336,7 @@ snapshots:
       '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       '@strapi/admin': 5.39.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)(typescript@5.4.4))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.12))(@types/node@24.12.2)(@types/react-dom@18.3.1)(@types/react@18.3.12)(better-sqlite3@12.6.2)(codemirror@5.65.21)(debug@4.3.4)(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/database': 5.39.0(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
+      '@strapi/database': 5.39.0(patch_hash=9c4780d1218c8890076fdec3b7f7455b15668a2706cad02d828572686276897c)(@types/node@24.12.2)(better-sqlite3@12.6.2)(pg@8.20.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.1)(@types/react@18.3.12)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/provider-upload-local': 5.39.0
@@ -39409,7 +39414,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next-sitemap@4.1.8(next@13.5.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0)):
+  next-sitemap@4.1.8(next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11


### PR DESCRIPTION
When migrating from Strapi v4 to v5, projects that used strapi-plugin-slugify stored slug fields as type "string" instead of the native "uid" type. String fields never receive a _unique index, so when the 5.0.0-05 migration attempts to DROP INDEX on those columns, PostgreSQL throws an error.

Unlike SQLite, PostgreSQL marks the entire transaction as aborted on any statement failure. The original catch() block silently swallowed the JavaScript error but left the transaction dead, causing every subsequent command including hasTable() to be rejected with:

 > current transaction is aborted, commands ignored until end of transaction block

Fix: wrap each DROP INDEX attempt in a SAVEPOINT / ROLLBACK TO SAVEPOINT so that failures are isolated at the savepoint level and the outer transaction remains healthy. Also wrap hasTable() in a try/catch to guard against any pre-existing broken transaction state from earlier migrations.

Applied as a pnpm patch to @strapi/database@5.39.0 until an upstream fix is available. Affects both the CJS (.js) and ESM (.mjs) build outputs.

Ref: https://github.com/strapi/strapi/issues/22960

<img width="1440" height="1500" alt="Why the index never existed" src="https://github.com/user-attachments/assets/37c64d4a-bc9b-4884-83a6-34e6bf2ff0be" />
