### PR TITLE
Fix/add missing engines to strapi admin extensions

### DIFF
--- a/apps/strapi-admin-extensions/package.json
+++ b/apps/strapi-admin-extensions/package.json
@@ -54,5 +54,9 @@
     "type": "git+ssh",
     "url": "git@github.com:frameless/strapi.git",
     "directory": "apps/strapi-admin-extensio0s"
+  },
+  "engines": {
+    "node": "24.x.x",
+    "pnpm": "10.23.0"
   }
 }


### PR DESCRIPTION
Fix the pdc-strapiadminextensions start niet en geeft de volgende foutmelding:
"This project is configured to use pnpm because /app/package.json has a 'packageManager' field"