### PR TITLE
build(strapi.frameless.io): fix the strapi.frameless.io deployment issue on Vercel

### DIFF
--- a/apps/strapi.frameless.io/vercel.json
+++ b/apps/strapi.frameless.io/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm --filter @frameless/strapi-docs build",
+  "framework": "docusaurus-2",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "relatedProjects": ["prj_G29LvoI23dh9tYuIDlnY8OQT4yYY"]
+}


### PR DESCRIPTION
- Resolves Docusaurus build failure caused by pnpm v9/v10 lockfile ambiguity
- Requires ENABLE_EXPERIMENTAL_COREPACK=1 in Vercel environment variables