### PR TITLE
fix: preserve locale and products path prefix in redirect URL

### DIFF
--- a/apps/pdc-frontend/src/util/getRedirectURL.test.ts
+++ b/apps/pdc-frontend/src/util/getRedirectURL.test.ts
@@ -22,18 +22,18 @@ describe('getRedirectURL', () => {
   it('should return the redirect url if a matching slug is found', () => {
     const redirectUrl = getRedirectURL({
       data: [{ slug: 'new-slug', oldSlugs: ['old-slug'] }],
-      url: new URL('https://example.com/old-slug'),
-      currentPathname: '/old-slug',
+      url: new URL('https://example.com/nl/products/old-slug'),
+      currentPathname: '/nl/products/old-slug',
     });
-    expect(redirectUrl?.pathname).toBe('/new-slug');
+    expect(redirectUrl?.pathname).toBe('/nl/products/new-slug');
   });
   it('should handle multiple old slugs', () => {
     const redirectUrl = getRedirectURL({
       data: [{ slug: 'new-slug', oldSlugs: ['old-slug', 'another-old-slug'] }],
-      url: new URL('https://example.com/another-old-slug'),
-      currentPathname: '/another-old-slug',
+      url: new URL('https://example.com/nl/products/another-old-slug'),
+      currentPathname: '/nl/products/another-old-slug',
     });
-    expect(redirectUrl?.pathname).toBe('/new-slug');
+    expect(redirectUrl?.pathname).toBe('/nl/products/new-slug');
   });
   it('should handle multiple data entries', () => {
     const redirectUrl = getRedirectURL({
@@ -41,10 +41,10 @@ describe('getRedirectURL', () => {
         { slug: 'new-slug', oldSlugs: ['old-slug'] },
         { slug: 'another-new-slug', oldSlugs: ['another-old-slug'] },
       ],
-      url: new URL('https://example.com/another-old-slug'),
-      currentPathname: '/another-old-slug',
+      url: new URL('https://example.com/nl/products/another-old-slug'),
+      currentPathname: '/nl/products/another-old-slug',
     });
-    expect(redirectUrl?.pathname).toBe('/another-new-slug');
+    expect(redirectUrl?.pathname).toBe('/nl/products/another-new-slug');
   });
   it('should handle empty old slugs', () => {
     const redirectUrl = getRedirectURL({

--- a/apps/pdc-frontend/src/util/getRedirectURL.ts
+++ b/apps/pdc-frontend/src/util/getRedirectURL.ts
@@ -17,11 +17,13 @@ interface GetRedirectURL {
  */
 export const getRedirectURL = ({ data, url, currentPathname }: GetRedirectURL): URL | null => {
   if (!Array.isArray(data)) return null;
-  const currentSlug = currentPathname.split('/').pop() || '';
+  const pathSegments = currentPathname.split('/');
+  const currentSlug = pathSegments.pop() || '';
+  const pathPrefix = pathSegments.join('/');
   for (const item of data) {
     if (Array.isArray(item.oldSlugs) && item.oldSlugs.includes(currentSlug)) {
       const redirectUrl = new URL(url.toString());
-      redirectUrl.pathname = new URL(item.slug, redirectUrl.origin).pathname;
+      redirectUrl.pathname = `${pathPrefix}/${item.slug}`;
       return redirectUrl;
     }
   }


### PR DESCRIPTION
The issue occurs when trying to access an old URL that should redirect to an updated one. The problem is that the `/products` path is not preserved during the redirect, which results in a `404` instead of navigating to the correct page.

**Example**:

- `https://example.com/products/old-slug`
redirects to
- `https://example.com/new-slug  (missing /products)`

It should redirect to:

- `https://example.com/products/new-slug`

This issue only happens in production; locally everything works as expected.

I suspect this is related to differences between runtimes. In production, the middleware runs in the Edge runtime (e.g., on Vercel), while locally it runs in the Node.js runtime.

One key difference is how `new URL(item.slug, base)` behaves, but the more likely root cause is the `referer` header:

- In development, browsers almost always include a `referer` header when navigating between pages. Because of this, the middleware exits early and never reaches the redirect logic.
- In production, direct visits (e.g., from search engines, shared links, or bookmarks) often do not include a `referer` header. As a result, the request reaches `getRedirectURL`, where the bug becomes visible.
