### PR TITLE
fix(overige-objecten-api): send null instead of empty string for owmsEndDate 

### DIFF
--- a/apps/overige-objecten-api/src/controllers/openapi/types.ts
+++ b/apps/overige-objecten-api/src/controllers/openapi/types.ts
@@ -181,7 +181,7 @@ export interface VerantwoordelijkeOrganisatie {
   url: string;
   owmsIdentifier: string;
   owmsPrefLabel?: string;
-  owmsEndDate: string;
+  owmsEndDate: string | null;
 }
 
 export interface Afdeling {

--- a/apps/overige-objecten-api/src/shared-types.ts
+++ b/apps/overige-objecten-api/src/shared-types.ts
@@ -223,7 +223,7 @@ export interface Afdelingen {
 export interface VerantwoordelijkeOrganisatie {
   owmsIdentifier: string;
   owmsPrefLabel: string;
-  owmsEndDate: string;
+  owmsEndDate: string | null;
 }
 
 export interface Kennisartikel {

--- a/apps/overige-objecten-api/src/utils/generateKennisartikelObject.ts
+++ b/apps/overige-objecten-api/src/utils/generateKennisartikelObject.ts
@@ -119,11 +119,11 @@ export const generateKennisartikelObject = ({
         productValtOnder: kennisartikelMetadata?.productValtOnder ?? null, // we need an extra field for this
         verantwoordelijkeOrganisatie: getVerantwoordelijkeOrganisatie({
           metadata: kennisartikelMetadata?.verantwoordelijkeOrganisatie ?? {
-            owmsEndDate: '',
+            owmsEndDate: null,
             owmsIdentifier: '',
           },
           url,
-        }),
+        }) as components['schemas']['kennisartikel']['verantwoordelijkeOrganisatie'],
         locaties: null, //Een lijst met locaties waarop dit product beschikbaar is. Deze is nog niet nodig voor KISS en mag null zijn. Dit obecjt is dus nog niet opgenomen in dit schema
         doelgroep: kennisartikelMetadata?.doelgroep?.replace('_', '-') as 'eu-burger' | 'eu-bedrijf',
         afdelingen: kennisartikelMetadata?.afdelingen,

--- a/apps/overige-objecten-api/src/utils/getVerantwoordelijkeOrganisatie.ts
+++ b/apps/overige-objecten-api/src/utils/getVerantwoordelijkeOrganisatie.ts
@@ -1,11 +1,11 @@
-import type { components } from '../types/openapi';
-
-export type ReturnedGetVerantwoordelijkeOrganisatieValue =
-  components['schemas']['kennisartikel']['verantwoordelijkeOrganisatie'];
-export interface GetVerantwoordelijkeOrganisatieProps {
-  metadata: Omit<components['schemas']['kennisartikel']['verantwoordelijkeOrganisatie'], 'url'>;
-  url: string;
-}
+export type {
+  ReturnedGetVerantwoordelijkeOrganisatieValue,
+  GetVerantwoordelijkeOrganisatieProps,
+} from './getVerantwoordelijkeOrganisatie.types';
+import type {
+  GetVerantwoordelijkeOrganisatieProps,
+  ReturnedGetVerantwoordelijkeOrganisatieValue,
+} from './getVerantwoordelijkeOrganisatie.types';
 
 export const getVerantwoordelijkeOrganisatie = ({
   metadata,
@@ -14,5 +14,5 @@ export const getVerantwoordelijkeOrganisatie = ({
   url: `${new URL('api/v2/objecttypes/kennisartikel', url).href}#verantwoordelijkeOrganisatie`,
   owmsIdentifier: metadata?.owmsIdentifier,
   owmsPrefLabel: metadata?.owmsPrefLabel,
-  owmsEndDate: metadata?.owmsEndDate,
+  owmsEndDate: metadata?.owmsEndDate || null,
 });

--- a/apps/overige-objecten-api/src/utils/getVerantwoordelijkeOrganisatie.types.ts
+++ b/apps/overige-objecten-api/src/utils/getVerantwoordelijkeOrganisatie.types.ts
@@ -1,0 +1,13 @@
+import type { components } from '../types/openapi';
+
+export type ReturnedGetVerantwoordelijkeOrganisatieValue = Omit<
+  components['schemas']['kennisartikel']['verantwoordelijkeOrganisatie'],
+  'owmsEndDate'
+> & { owmsEndDate: string | null };
+
+export interface GetVerantwoordelijkeOrganisatieProps {
+  metadata: Omit<components['schemas']['kennisartikel']['verantwoordelijkeOrganisatie'], 'url' | 'owmsEndDate'> & {
+    owmsEndDate?: string | null;
+  };
+  url: string;
+}


### PR DESCRIPTION
  Elasticsearch's date field cannot parse an empty string, causing document                                             
  indexing failures for kennisbank records. Changed the fallback default for                                            
  owmsEndDate from '' to null, added a defensive || null conversion in                                                  
  getVerantwoordelijkeOrganisatie, and widened the owmsEndDate type to                                                  
  string | null in shared-types and controllers/openapi/types.  