### PR TITLE
Fix the overige objecten api and pdc frontend image issue

### DIFF
--- a/apps/overige-objecten-api/src/controllers/objects/index.ts
+++ b/apps/overige-objecten-api/src/controllers/objects/index.ts
@@ -2,18 +2,17 @@ import { fetchData } from '@frameless/utils';
 import type { RequestHandler } from 'express';
 
 import { GET_ALL_PRODUCTS, GET_ALL_VAC_ITEMS } from '../../queries';
-import { getObjectByUUID } from '../../service/object';
+import { getObjectByUUID, formatKennisartikel } from '../../service/object';
 import type { components } from '../../types/openapi';
-import { generateKennisartikelObject, getPaginatedResponse, getTheServerURL, getVacData } from '../../utils';
+import { getPaginatedResponse, getTheServerURL, getVacData } from '../../utils';
 import type { PaginationType } from '../../utils';
-import type { GetAllProductsQuery, GetAllVacItemsQuery } from '../../../gql/graphql';
-import type { KennisartikelMetadata, PageSection, PriceItem } from '../../shared-types';
+import type { GetAllProductsQuery, GetAllVacItemsQuery, GetProductByUuidOrDocumentIdQuery } from '../../../gql/graphql';
 
 type GetKennisartikelReturnData = components['schemas']['ObjectData'];
 
 const sum = (a: number, b: number): number => a + b;
 const isFiniteNumber = (arg: unknown): arg is number => typeof arg === 'number' && isFinite(arg);
-let results: any = [];
+let results: GetKennisartikelReturnData[] = [];
 let pagination: PaginationType = {};
 export const getAllObjectsController: RequestHandler = async (req, res, next) => {
   try {
@@ -59,56 +58,16 @@ export const getAllObjectsController: RequestHandler = async (req, res, next) =>
     }: {
       data: GetAllProductsQuery | undefined;
     }): GetKennisartikelReturnData[] => {
+      const isDefined = <T>(argument: T | undefined | null): argument is T =>
+        argument !== null && argument !== undefined;
       const products = data?.products_connection?.nodes ?? [];
       if (products.length === 0) return [];
-      return products.map((product) => {
-        const modifiedProduct = {
-          ...product,
-          sections: [
-            {
-              component: 'ComponentComponentsUtrechtRichText',
-              content: product?.content,
-              kennisartikelCategorie: 'inleiding',
-              categorie5: 'inleiding',
-            },
-            ...(product.sections ?? []),
-          ],
-        };
-        return generateKennisartikelObject({
-          sections: (modifiedProduct.sections?.filter(Boolean) ?? []) as PageSection[],
-          title: modifiedProduct.title,
-          uuid: modifiedProduct?.uuid,
-          locale: modifiedProduct.locale,
-          updatedAt: modifiedProduct.updatedAt,
-          createdAt: modifiedProduct.createdAt,
-          metaTags: modifiedProduct.metaTags ?? null,
-          kennisartikelMetadata: (modifiedProduct.kennisartikelMetadata as KennisartikelMetadata) ?? null,
-          price: modifiedProduct.price
-            ? {
-                price: (modifiedProduct.price.price?.filter(Boolean) ?? []) as PriceItem[],
-              }
-            : null,
-          additional_information: {
-            content: {
-              uuid: modifiedProduct.additional_information?.content?.uuid ?? '',
-              // Map the content blocks to match your ContentBlock interface exactly
-              contentBlock: (modifiedProduct.additional_information?.content?.contentBlock ?? [])
-                .filter((block): block is NonNullable<typeof block> => block !== null)
-                .map((block) => ({
-                  id: block.id,
-                  content: block.content,
-                  // Map the GraphQL 'categorie10' to the required 'kennisartikelCategorie'
-                  kennisartikelCategorie: block.categorie10 ?? 'onbekend',
-                  categorie10: block.categorie10,
-                  component: 'ComponentComponentsUtrechtRichText' as const,
-                })),
-            },
-          },
-          id: modifiedProduct.id,
-          url: serverURL,
-          publicationState: 'PUBLISHED',
-        });
-      });
+      type GQLProduct = NonNullable<NonNullable<GetProductByUuidOrDocumentIdQuery['products']>[number]>;
+      return products
+        .filter(isDefined)
+        .map(
+          (product) => formatKennisartikel(product as GQLProduct, serverURL, 'PUBLISHED') as GetKennisartikelReturnData,
+        );
     };
     const fetchVac = async () => {
       // Fetch VACs data from GraphQL
@@ -134,7 +93,7 @@ export const getAllObjectsController: RequestHandler = async (req, res, next) =>
       const data = await fetchVac();
       const vac = getVacData({ data, serverURL, vacSchemaURL });
       pagination = await getPaginatedResponse(req, data?.vacs_connection?.pageInfo ?? undefined);
-      results = vac;
+      results = vac as unknown as GetKennisartikelReturnData[];
     } else if (!type && !isVac && !isKennisartikel) {
       const productsData = await fetchKennisartikelen();
       const data = await fetchVac();
@@ -153,7 +112,7 @@ export const getAllObjectsController: RequestHandler = async (req, res, next) =>
       };
       const kennisartikelData = getKennisartikelData({ data: productsData });
       const vac = getVacData({ data, serverURL, vacSchemaURL });
-      results = [...kennisartikelData, ...vac];
+      results = [...kennisartikelData, ...(vac as unknown as GetKennisartikelReturnData[])];
     } else {
       pagination = {
         page: 0,
@@ -196,9 +155,11 @@ export const getObjectByUUIDController: RequestHandler = async (req, res, next) 
     });
 
     return res.status(200).set('Content-Type', 'application/json').json(object);
-  } catch (error: any) {
-    if (error.message === 'UUID not provided' || error.message === 'Object not found') {
-      return res.status(404).json({ message: error.message });
+  } catch (error: unknown) {
+    // Forward any errors to the error handler middleware
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    if (errorMessage === 'UUID not provided' || errorMessage === 'Object not found') {
+      return res.status(404).json({ message: errorMessage });
     }
     next(error);
     return null;

--- a/apps/overige-objecten-api/src/queries/index.ts
+++ b/apps/overige-objecten-api/src/queries/index.ts
@@ -25,6 +25,7 @@ query getAllProducts(
     nodes {
       id: documentId
       documentId
+      publishedAt
       content
       title
       slug
@@ -38,33 +39,35 @@ query getAllProducts(
         description
       }
       sections {
-        __typename
         ... on ComponentComponentsContactInformationPublic {
+          component: __typename
           contact_information_public {
-            contentBlock(pagination: { limit: -1 }) {
+            contentBlock(pagination: { start: 0, limit: -1 }) {
               id
               content
             }
           }
         }
         ... on ComponentComponentsInternalBlockContent {
+          component: __typename
           id
           internal_field {
             title
             id: documentId
             contact_information_internal {
-              contentBlock(pagination: { limit: -1 }) {
+              contentBlock(pagination: { start: 0, limit: -1 }) {
                 id
                 content
               }
             }
             contact_information_public {
-              contentBlock(pagination: { limit: -1 }) {
+              contentBlock(pagination: { start: 0, limit: -1 }) {
                 id
                 content
               }
             }
             content {
+              id
               uuid
               contentBlock {
                 content
@@ -75,11 +78,14 @@ query getAllProducts(
           }
         }
         ... on ComponentComponentsUtrechtRichText {
+          component: __typename
           id
           content
           kennisartikelCategorie
+          categorie5: kennisartikelCategorie
         }
         ... on ComponentComponentsUtrechtImage {
+          component: __typename
           categorie2: kennisartikelCategorie
           imageData {
             name
@@ -92,6 +98,7 @@ query getAllProducts(
           }
         }
         ... on ComponentComponentsUtrechtLogoButton {
+          component: __typename
           categorie3: kennisartikelCategorie
           appearance
           href
@@ -101,6 +108,7 @@ query getAllProducts(
           textContent
         }
         ... on ComponentComponentsUtrechtSpotlight {
+          component: __typename
           categorie4: kennisartikelCategorie
           content
           type
@@ -111,14 +119,17 @@ query getAllProducts(
             textContent
             logo
             appearance
+            __typename
           }
         }
         ... on ComponentComponentsUtrechtMultiColumnsButton {
+          component: __typename
           categorie6: kennisartikelCategorie
           column {
             id
             title
             logoButton {
+              component: __typename
               appearance
               href
               label
@@ -129,6 +140,7 @@ query getAllProducts(
           }
         }
         ... on ComponentComponentsUtrechtLink {
+          component: __typename
           categorie7: kennisartikelCategorie
           href
           textContent
@@ -136,10 +148,11 @@ query getAllProducts(
           language
         }
         ... on ComponentComponentsFaq {
+          component: __typename
           categorie8: kennisartikelCategorie
           pdc_faq {
             title
-            faq(pagination: { limit: -1 }) {
+            faq(pagination: { start: 0, limit: -1 }) {
               body
               headingLevel
               id
@@ -148,8 +161,9 @@ query getAllProducts(
           }
         }
         ... on ComponentComponentsUtrechtAccordion {
+          component: __typename
           categorie9: kennisartikelCategorie
-          item(pagination: { limit: -1 }) {
+          item(pagination: { start: 0, limit: -1 }) {
             body
             headingLevel
             id
@@ -161,15 +175,16 @@ query getAllProducts(
         content {
           id
           uuid
-          contentBlock(pagination: { limit: -1 }) {
+          contentBlock(pagination: { start: 0, limit: -1 }) {
             id
             content
             categorie10: kennisartikelCategorie
+            component: __typename
           }
         }
       }
       price {
-        price(pagination: { limit: -1 }) {
+        price(pagination: { start: 0, limit: -1 }) {
           currency
           id
           label
@@ -197,7 +212,6 @@ query getAllProducts(
   }
 }
 `);
-
 export const GET_PRODUCT_BY_UUID = gql(`
 query getProductByUUIDOrDocumentId(
   $locale: I18NLocaleCode

--- a/apps/overige-objecten-api/src/service/object.ts
+++ b/apps/overige-objecten-api/src/service/object.ts
@@ -23,7 +23,7 @@ const isDefined = <T>(argument: T | undefined | null): argument is T => argument
 const getStatus = (items: (GQLProduct | GQLVac | null | undefined)[]): 'DRAFT' | 'PUBLISHED' =>
   items.filter(isDefined)[0]?.publishedAt === null ? 'DRAFT' : 'PUBLISHED';
 
-const formatKennisartikel = (
+export const formatKennisartikel = (
   product: GQLProduct,
   serverURL: string,
   publicationState: 'DRAFT' | 'PUBLISHED',
@@ -50,7 +50,7 @@ const formatKennisartikel = (
     url: serverURL,
     uuid: safeUuid,
     locale: product.locale ?? 'nl',
-    title: product.title ?? '',
+    title: product.title,
     updatedAt: product.updatedAt,
     createdAt: product.createdAt,
     publicationState,

--- a/apps/pdc-frontend/next.config.mjs
+++ b/apps/pdc-frontend/next.config.mjs
@@ -1,6 +1,6 @@
 import { URL } from 'node:url';
 
-const { hostname, protocol, port } = new URL(process.env.STRAPI_PRIVATE_URL || 'http://localhost:1337');
+const { hostname, protocol, port } = new URL(process.env.STRAPI_PUBLIC_URL || 'http://localhost:1337');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
**Overige-objecten-api:**
Het probleem was dat de categorieën niet werden getoond op het KISS-dashboard, alleen de “inleiding”.

<img width="1026" height="203" alt="Screenshot 2026-05-28 at 11 20 09" src="https://github.com/user-attachments/assets/b48d7e8d-a360-4259-9ca7-565a1aa05b0c" />

**Digital Loket website:**
Hier werd de verkeerde ENV-variabele gebruikt. Dit is aangepast naar `STRAPI_PUBLIC_URL` in plaats van `STRAPI_PRIVATE_URL`.

De private variabele is bedoeld voor interne communicatie (zoals server-side fetch-operaties), terwijl afbeeldingen via de browser de public URL moeten gebruiken.

