### PR TITLE
fix(pdc-frontend): update the base URL for PDC images

### DIFF
--- a/apps/pdc-frontend/src/util/getImageBaseUrl.ts
+++ b/apps/pdc-frontend/src/util/getImageBaseUrl.ts
@@ -3,7 +3,7 @@ import { buildURL } from '@frameless/utils';
 export const getImageBaseUrl = (segment?: string): string => {
   const url = buildURL({
     env: process.env,
-    key: 'STRAPI_PRIVATE_URL',
+    key: 'STRAPI_PUBLIC_URL',
     segments: segment ? [segment] : [],
   });
   if (!url) throw new Error('getImageBaseUrl: Failed to build image URL');


### PR DESCRIPTION
Use the public URL for Product Data Center (PDC) images instead of the internal private URL, as the latter is not accessible from the public internet.

This change ensures that PDC images are loaded correctly in the frontend application.