### PR TITLE
fix(overige-objecten-api): guard against null relations in processData and HTML converters

### DIFF
--- a/apps/overige-objecten-api/src/utils/convertMultiColumnsButtonToHTML.tsx
+++ b/apps/overige-objecten-api/src/utils/convertMultiColumnsButtonToHTML.tsx
@@ -20,7 +20,7 @@ const MultiColumnsButton = ({ item, withDesignSystem }: MultiColumnsButtonProps)
     return (
       <div style={{ display: 'inline-grid' }}>
         <Heading level={3}>{item.title}</Heading>
-        {item.logoButton.map((btn: LogoButtonItemType, index: number) => (
+        {item.logoButton?.map((btn: LogoButtonItemType, index: number) => (
           <LogoButton item={btn} headingLevel={4} key={index} />
         ))}
       </div>
@@ -29,7 +29,7 @@ const MultiColumnsButton = ({ item, withDesignSystem }: MultiColumnsButtonProps)
   return (
     <div style={{ display: 'inline-grid' }}>
       <h3>{item.title}</h3>
-      {item.logoButton.map((btn: LogoButtonItemType, index: number) => (
+      {item.logoButton?.map((btn: LogoButtonItemType, index: number) => (
         <BasicLogoButton item={btn} headingLevel={4} key={index} />
       ))}
     </div>
@@ -37,6 +37,6 @@ const MultiColumnsButton = ({ item, withDesignSystem }: MultiColumnsButtonProps)
 };
 
 export const convertMultiColumnsButtonToHTML = (item: MultiColumnsButtonTypes, withDesignSystem?: boolean) =>
-  item.column
+  (item.column ?? [])
     .map((col) => renderToString(<MultiColumnsButton item={col} withDesignSystem={withDesignSystem} key={col.title} />))
     .join('');

--- a/apps/overige-objecten-api/src/utils/generateKennisartikelObject.ts
+++ b/apps/overige-objecten-api/src/utils/generateKennisartikelObject.ts
@@ -45,7 +45,7 @@ export const generateKennisartikelObject = ({
     categoryKey: 'categorie10',
   });
   const mergedContactInformationInternal = getInternalField?.contact_information_internal?.flatMap(
-    (item) => item.contentBlock,
+    (item) => item?.contentBlock ?? [],
   );
   const contactInformationInternal = mergedContactInformationInternal;
   const contactInformationPublic = getInternalField?.contact_information_public?.contentBlock;
@@ -64,7 +64,7 @@ export const generateKennisartikelObject = ({
 
       // Scenario B: It's nested inside the internal block
       if (isInternalBlock(block)) {
-        return block.internal_field.contact_information_public?.contentBlock ?? [];
+        return block.internal_field?.contact_information_public?.contentBlock ?? [];
       }
 
       return [];

--- a/apps/overige-objecten-api/src/utils/processData.tsx
+++ b/apps/overige-objecten-api/src/utils/processData.tsx
@@ -80,6 +80,7 @@ const renderMultiColumnsButton = (item: MultiColumnsButton): Record<string, stri
   mapContent(item.categorie, convertMultiColumnsButtonToHTML(item));
 
 const renderFaq = (item: FaqComponent): Record<string, string> => {
+  if (!item.pdc_faq?.faq) return {};
   const html = safeRenderToString(
     <>
       {item.pdc_faq.faq.map((faq, index) => (
@@ -104,6 +105,7 @@ const renderLink = (item: UtrechtLink): Record<string, string> => {
 };
 
 const renderAccordion = (item: UtrechtAccordion): Record<string, string> => {
+  if (!item.item) return {};
   const html = safeRenderToString(
     <>
       {item.item.map((accordionItem) => (


### PR DESCRIPTION
Strapi can return null for relation fields that TypeScript types mark as
non-nullable. Added null guards in renderFaq (pdc_faq), renderAccordion
(item), convertMultiColumnsButtonToHTML (column and logoButton) to prevent
TypeError crashes on the deployed version.