### PR TITLE
fix: allow multiple truthy string values for NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP

### DIFF
--- a/apps/pdc-frontend/next.config.mjs
+++ b/apps/pdc-frontend/next.config.mjs
@@ -39,11 +39,13 @@ const nextConfig = {
     // https://nextjs.org/docs/app/api-reference/components/image#dangerouslyallowlocalip
     // In development localhost always resolves to a private IP, so allow it unconditionally.
     // In production this is only needed when Next.js and Strapi share the same Docker host
-    // (i.e. STRAPI_PUBLIC_URL resolves to a private Docker bridge IP). Set
+    // or Kubernetes cluster (i.e. STRAPI_PUBLIC_URL resolves to a private IP). Set
     // NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP=true in that environment. Safe because
     // remotePatterns already restricts the image optimizer to a single trusted hostname.
+    // See: https://nextjs.org/docs/app/api-reference/components/image#dangerouslyallowlocalip
     dangerouslyAllowLocalIP:
-      process.env.NODE_ENV === 'development' || process.env.NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP === 'true',
+      process.env.NODE_ENV === 'development' ||
+      ['true', '1'].includes(process.env.NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP),
     remotePatterns: [
       {
         protocol: protocol.replace(/:$/, ''),

--- a/apps/vth-frontend/next.config.js
+++ b/apps/vth-frontend/next.config.js
@@ -11,12 +11,13 @@ const nextConfig = {
   images: {
     // In development localhost always resolves to a private IP, so allow it unconditionally.
     // In production this is only needed when Next.js and Strapi share the same Docker host
-    // (i.e. STRAPI_PUBLIC_URL resolves to a private Docker bridge IP). Set
+    // or Kubernetes cluster (i.e. STRAPI_PUBLIC_URL resolves to a private IP). Set
     // NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP=true in that environment. Safe because
     // remotePatterns already restricts the image optimizer to a single trusted hostname.
-    // https://nextjs.org/docs/app/api-reference/components/image#dangerouslyallowlocalip
+    // See: https://nextjs.org/docs/app/api-reference/components/image#dangerouslyallowlocalip
     dangerouslyAllowLocalIP:
-      process.env.NODE_ENV === 'development' || process.env.NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP === 'true',
+      process.env.NODE_ENV === 'development' ||
+      ['true', '1'].includes(process.env.NEXT_IMAGES_DANGEROUSLY_ALLOW_LOCAL_IP),
     remotePatterns: [
       {
         protocol: protocol.replace(/:$/, ''),


### PR DESCRIPTION
Support both 'true' and '1' as valid values for enabling local IP access.

Since Node.js environment variables are always strings (or undefined),
this normalizes configuration across deployment environments such as
Kubernetes and Helm, which may represent boolean values differently in YAML.

