### PR TITLE
fix(docker): pin turbo version in Dockerfile to prevent broken pruned lockfile

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -17,7 +17,7 @@ FROM base AS pruner
 COPY . .
 
 # Prune everything - no specific app, builds all
-RUN pnpm dlx turbo prune \
+RUN pnpm dlx turbo@2.8.13 prune \
     @frameless/pdc-dashboard \
     @frameless/vth-dashboard \
     @frameless/pdc-frontend \


### PR DESCRIPTION
pnpm dlx turbo without a version specifier downloads whatever turbo version
is available at build time, which can differ from the project's installed
turbo@2.8.13. The version mismatch caused turbo prune --docker to generate
a pruned pnpm-lock.yaml missing the react-loading-skeleton@3.3.1(react@19.2.6)
snapshot entry, making pnpm install --frozen-lockfile fail in the deps stage.

Pinning to turbo@2.8.13 ensures the same lockfile pruning behavior in Docker
as locally.
