### PR TITLE
fix(pdc-dashboard): restore translated labels for enum dropdown fields in Strapi v5

### DIFF
--- a/.changeset/some-toys-refuse.md
+++ b/.changeset/some-toys-refuse.md
@@ -1,0 +1,7 @@
+---
+"@frameless/pdc-dashboard": patch
+---
+
+Dropdownvelden in het dashboard tonen nu weer hun vertaalde labels (bijv. “Inwoners (blauw)” in plaats van “primary-action-button”). Dit was stuk na de upgrade naar Strapi 5, die stopte met het gebruiken van de vertaal­sleutels die in de adminconfiguratie voor enumvelden zijn gedefinieerd.
+
+([GitHub Issue Frameless/strapi#1483](https://github.com/frameless/strapi/issues/1483))

--- a/apps/pdc-dashboard/package.json
+++ b/apps/pdc-dashboard/package.json
@@ -17,7 +17,8 @@
     "lint-build": "tsc --noEmit --project tsconfig.json",
     "clean": "rimraf build .cache dist .strapi",
     "config-sync-export": "config-sync export",
-    "config-sync-import": "config-sync import"
+    "config-sync-import": "config-sync import",
+    "check:enum-workaround": "node ../../scripts/check-strapi-enum-workaround.mjs"
   },
   "dependencies": {
     "@frameless/content-compliance-checker": "1.0.2",

--- a/apps/pdc-dashboard/src/admin/app.ts
+++ b/apps/pdc-dashboard/src/admin/app.ts
@@ -1,5 +1,6 @@
 import UtrechtFavicon from './extensions/favicon.ico';
 import UtrechtLogo from './extensions/logo.svg';
+import TranslatedEnumerationInput from './extensions/TranslatedEnumerationInput';
 
 const config = {
   locales: ['nl'],
@@ -33,6 +34,7 @@ const config = {
       info: 'Blue',
       warning: 'Yellow',
       gray: 'Gray',
+      arrow: 'Arrow',
       'dark-mode': 'Dark Mode Detection',
       'forced-colors': 'Forced Color Mode Detection',
       'google-translate': 'Google Translate Detection',
@@ -95,7 +97,9 @@ const config = {
   },
 };
 
-const bootstrap = () => {};
+const bootstrap = ({ addFields }: { addFields: (_field: object) => void }) => {
+  addFields({ type: 'enumeration', Component: TranslatedEnumerationInput });
+};
 
 export default {
   config,

--- a/apps/pdc-dashboard/src/admin/extensions/TranslatedEnumerationInput.md
+++ b/apps/pdc-dashboard/src/admin/extensions/TranslatedEnumerationInput.md
@@ -1,0 +1,108 @@
+# TranslatedEnumerationInput — workaround for missing enum labels in Strapi v5
+
+## Background
+
+In Strapi v4 the content-manager's `InputRenderer` called `intl.formatMessage({ id: enumValue })` when building dropdown options for enumeration fields. This meant enum values like `primary-action-button` were automatically resolved via the admin i18n config, so users saw translated labels.
+
+In Strapi v5 this was removed. Options are now built as `{ value }` only — no label — so raw enum strings appear in the UI instead of translated labels.
+
+Relevant upstream files:
+
+- [`@strapi/admin` — `Enumeration.tsx`](https://github.com/strapi/strapi/blob/develop/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx#L39)
+- [`@strapi/content-manager` — `InputRenderer.tsx`](https://github.com/strapi/strapi/blob/develop/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx#L258)
+
+Tracked in: [strapi/strapi#26683 — Regression: Enumeration field no longer supports i18n translation in admin (v4 → v5)](https://github.com/strapi/strapi/issues/26683)
+
+## The fix
+
+`TranslatedEnumerationInput.tsx` replicates Strapi's built-in enumeration input but maps `attribute.enum` through `formatMessage`, restoring the v4 behaviour. It is registered globally in `admin/app.ts` via `app.addFields({ type: 'enumeration', ... })`, which intercepts all enumeration fields before Strapi's own switch-case runs.
+
+If a translation key is missing, the raw enum value is shown as a fallback (`defaultMessage: value`).
+
+---
+
+## Upgrade checklist — run after every Strapi update
+
+After running `pnpm update @strapi/strapi` (or any `@strapi/*` package), execute:
+
+```sh
+pnpm check:enum-workaround
+```
+
+| Output                                                  | Meaning                                                                           |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `OK: workaround still needed`                           | Nothing to do.                                                                    |
+| `ACTION REQUIRED: Strapi has restored enum translation` | Follow the removal steps printed by the script.                                   |
+| `WARNING: Could not isolate the enumeration case block` | Strapi restructured the file — inspect manually (see script output for the path). |
+
+### If the workaround can be removed
+
+1. Delete `TranslatedEnumerationInput.tsx` (this file's sibling).
+2. Remove the `addFields({ type: 'enumeration', ... })` call in `apps/pdc-dashboard/src/admin/app.ts`.
+3. Verify in the UI using the manual test below.
+
+---
+
+## Manual UI test
+
+Use this to confirm the workaround (or the native Strapi fix after removal) is working correctly.
+
+### Setup
+
+Open the Strapi admin dashboard and go to **Content Manager → Products**. Open any existing product (or create one) that has a **Sections** dynamic zone.
+
+---
+
+### CTA component — Appearance field
+
+1. In the Sections zone, add or open a **Call to Action Knop (CTA)** component.
+2. Click the **Appearance** dropdown.
+
+| Raw enum value            | Expected label (NL)    | Expected label (EN) |
+| ------------------------- | ---------------------- | ------------------- |
+| `primary-action-button`   | Inwoners (blauw)       | Primary             |
+| `secondary-action-button` | Aanvullende knop (wit) | Secondary           |
+| `magenta`                 | Organisaties (paars)   | Magenta             |
+
+---
+
+### CTA / Logo button component — Logo field
+
+1. Inside the same CTA (or open a **Logo button** component), click the **Logo** dropdown.
+
+| Raw enum value | Expected label             |
+| -------------- | -------------------------- |
+| `digid`        | DigiD                      |
+| `eherkenning`  | eHerkenning                |
+| `eidas`        | eIDAS                      |
+| `without_logo` | Without logo / Zonder logo |
+
+---
+
+### Spotlight component — Type field
+
+1. Add or open a **Spotlight** component in the Sections zone.
+2. Click the **Soort** (type) dropdown.
+
+| Raw enum value | Expected label (NL) | Expected label (EN) |
+| -------------- | ------------------- | ------------------- |
+| `gray`         | Grijs               | Gray                |
+| `info`         | Blauw               | Blue                |
+| `warning`      | Geel                | Yellow              |
+
+---
+
+### Link component — Icon field
+
+1. Open a component that contains a **Link** (e.g. a repeatable Links field).
+2. Click the **Icon** dropdown.
+
+| Raw enum value | Expected label (NL) | Expected label (EN) |
+| -------------- | ------------------- | ------------------- |
+| `arrow`        | Pijl                | Arrow               |
+
+---
+
+### Failure signature
+
+If you see **raw enum values** (`primary-action-button`, `magenta`, `gray`, `arrow`, etc.) instead of translated labels, the workaround is either missing or broken.

--- a/apps/pdc-dashboard/src/admin/extensions/TranslatedEnumerationInput.tsx
+++ b/apps/pdc-dashboard/src/admin/extensions/TranslatedEnumerationInput.tsx
@@ -1,0 +1,76 @@
+/**
+ * Workaround for Strapi v5 removing enum label translation support.
+ * Background, upgrade checklist, and manual UI test: ./TranslatedEnumerationInput.md
+ * After every Strapi upgrade run: node scripts/check-strapi-enum-workaround.mjs
+ */
+
+import { forwardRef, memo } from 'react';
+import type { ReactNode } from 'react';
+import { Field, SingleSelect, SingleSelectOption, useComposedRefs } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+import { useField, useFocusInputField } from '@strapi/admin/strapi-admin';
+
+interface EnumAttribute {
+  type: 'enumeration';
+  enum: string[];
+  required?: boolean;
+  default?: string;
+}
+
+interface TranslatedEnumerationInputProps {
+  name: string;
+  label?: ReactNode;
+  hint?: ReactNode;
+  required?: boolean;
+  labelAction?: ReactNode;
+  attribute: EnumAttribute;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const TranslatedEnumerationInput = forwardRef<HTMLDivElement, TranslatedEnumerationInputProps>(
+  ({ name, required, label, hint, labelAction, attribute, disabled, placeholder }, ref) => {
+    const { formatMessage } = useIntl();
+    const field = useField(name);
+    const fieldRef = useFocusInputField<HTMLDivElement>(name);
+    const composedRefs = useComposedRefs(ref, fieldRef);
+
+    const options = (attribute?.enum ?? []).map((value) => ({
+      value,
+      label: formatMessage({ id: value, defaultMessage: value }),
+    }));
+
+    return (
+      <Field.Root error={field.error} name={name} hint={hint} required={required}>
+        <Field.Label action={labelAction}>{label}</Field.Label>
+        <SingleSelect
+          ref={composedRefs}
+          onChange={(value) => {
+            field.onChange(name, value === '' ? null : value);
+          }}
+          value={field.value}
+          disabled={disabled}
+          placeholder={placeholder}
+        >
+          <SingleSelectOption value="" disabled={required} hidden={required}>
+            {formatMessage({
+              id: 'components.InputSelect.option.placeholder',
+              defaultMessage: 'Choose here',
+            })}
+          </SingleSelectOption>
+          {options.map(({ value, label: optionLabel }) => (
+            <SingleSelectOption key={value} value={value}>
+              {optionLabel}
+            </SingleSelectOption>
+          ))}
+        </SingleSelect>
+        <Field.Hint />
+        <Field.Error />
+      </Field.Root>
+    );
+  },
+);
+
+TranslatedEnumerationInput.displayName = 'TranslatedEnumerationInput';
+
+export default memo(TranslatedEnumerationInput);

--- a/scripts/check-strapi-enum-workaround.mjs
+++ b/scripts/check-strapi-enum-workaround.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Checks whether the TranslatedEnumerationInput workaround in pdc-dashboard is still needed.
+ *
+ * Run this after every Strapi upgrade:
+ *   node scripts/check-strapi-enum-workaround.mjs
+ *
+ * Exit codes:
+ *   0 — workaround still needed, no action required
+ *   1 — Strapi appears to have restored enum translation; workaround can likely be removed
+ *   2 — could not locate or parse the file; manual inspection needed
+ */
+
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PNPM_STORE = join(ROOT, 'node_modules', '.pnpm');
+const TARGET_SUFFIX = '/@strapi/content-manager/dist/admin/pages/EditView/components/InputRenderer.js';
+const WORKAROUND_FILE = 'apps/pdc-dashboard/src/admin/extensions/TranslatedEnumerationInput.tsx';
+
+// Locate the installed InputRenderer.js inside the pnpm content-addressable store.
+let inputRendererPath;
+try {
+  const result = execSync(`find "${PNPM_STORE}" -path "*${TARGET_SUFFIX}" 2>/dev/null`, { encoding: 'utf-8' }).trim();
+  inputRendererPath = result.split('\n')[0];
+} catch {
+  // execSync throws if the command itself fails (not just empty output)
+}
+
+if (!inputRendererPath) {
+  console.error('ERROR: Could not find @strapi/content-manager InputRenderer.js under', PNPM_STORE);
+  console.error('       Is @strapi/content-manager installed?');
+  process.exit(2);
+}
+
+console.log('Checking:', inputRendererPath);
+
+const source = readFileSync(inputRendererPath, 'utf-8');
+
+// Isolate the enumeration case block. It ends at the next `case '` or `default:`.
+const enumCaseMatch = source.match(/case 'enumeration':([\s\S]*?)(?=case '|default:)/);
+
+if (!enumCaseMatch) {
+  console.warn('WARNING: Could not isolate the enumeration case block.');
+  console.warn('         Strapi may have restructured InputRenderer.js — inspect manually.');
+  console.warn('         File:', inputRendererPath);
+  process.exit(2);
+}
+
+const enumBlock = enumCaseMatch[1];
+const hasTranslation = /formatMessage/.test(enumBlock);
+
+if (hasTranslation) {
+  console.log('');
+  console.log('ACTION REQUIRED: Strapi has restored enum translation support.');
+  console.log('The workaround can likely be removed. Steps:');
+  console.log('  1. Delete', WORKAROUND_FILE);
+  console.log('  2. Remove the addFields({ type: "enumeration", ... }) call in');
+  console.log('     apps/pdc-dashboard/src/admin/app.ts');
+  console.log('  3. Verify in the UI: open a Product with a logo button and confirm');
+  console.log('     the Appearance dropdown still shows translated labels.');
+  process.exit(1);
+} else {
+  console.log('OK: Strapi still omits translation for enum options — workaround still needed.');
+  console.log('    No action required.');
+  process.exit(0);
+}


### PR DESCRIPTION
[issue](https://github.com/frameless/strapi/issues/1483)

**Before**:
 
<img width="1135" height="617" alt="Screenshot 2026-06-15 at 12 29 20" src="https://github.com/user-attachments/assets/14f8f042-ee80-4cf4-96f7-72df7a995ef7" />

<img width="1135" height="491" alt="Screenshot 2026-06-15 at 12 30 36" src="https://github.com/user-attachments/assets/8fd461c3-3351-4e32-843d-8d05efc511bd" />

<img width="1135" height="425" alt="Screenshot 2026-06-15 at 12 32 43" src="https://github.com/user-attachments/assets/5e6ceab8-a7f8-48a7-8310-145de8c33c84" />

**After**:

<img width="1135" height="674" alt="Screenshot 2026-06-15 at 12 34 29" src="https://github.com/user-attachments/assets/b7105872-cab0-4dc0-9a17-6940a4b69cf3" />

<img width="1135" height="495" alt="Screenshot 2026-06-15 at 12 35 33" src="https://github.com/user-attachments/assets/b32a9b0d-e54b-49c1-bb86-f9e66ec9b222" />

<img width="1135" height="495" alt="Screenshot 2026-06-15 at 12 39 36" src="https://github.com/user-attachments/assets/c35fcea0-ba4b-4c6a-9c19-d85b059dca32" />
