### PR TITLE
ci(docker): disable lifecycle scripts in production install

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -89,7 +89,7 @@ COPY --from=builder /app .
 COPY bin ./bin
 RUN chmod +x ./bin/wait-for-it.sh 2>/dev/null || true
 
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 RUN addgroup -S pdcgroup -g 1001 \
     && adduser -S pdcuser -u 1001 -G pdcgroup \


### PR DESCRIPTION
Prevents execution of prepare/postinstall scripts (e.g. Husky) during the runtime image build. This avoids failures caused by missing dev dependencies in the production stage when installing with --prod.

