### PR TITLE
style: utrecht theme heading spacing

### DIFF
--- a/apps/pdc-frontend/src/styles/globals.css
+++ b/apps/pdc-frontend/src/styles/globals.css
@@ -50,7 +50,7 @@ h6 {
   --utrecht-spotlight-section-margin-block-end: 16px;
   --utrecht-link-list-marker-background-image: url("https://pki.utrecht.nl/Loket/base/files/getImageAction.do?key=kl_pijltje-wit-SVG");
   --utrecht-list-social-margin-block-start: 24px;
-  --utrecht-heading-1-margin-block-start: var(--utrecht-space-block-2xl);
+  --utrecht-heading-1-margin-block-start: 0;
   --utrecht-heading-1-margin-block-end: var(--utrecht-space-block-2xl);
   --utrecht-page-footer-background-image: linear-gradient(
     45deg,


### PR DESCRIPTION

### Before:
<img width="837" height="593" alt="Screenshot 2026-06-17 at 11 26 22" src="https://github.com/user-attachments/assets/42ec69b1-c562-4d3e-a340-364ae082c59b" />

### After:
<img width="837" height="593" alt="Screenshot 2026-06-17 at 11 26 14" src="https://github.com/user-attachments/assets/7efa34c0-4378-4a0e-b0b2-96b7ceeb2625" />

#### Heading `margin-block-start: 0;`
<img width="683" height="291" alt="Screenshot 2026-06-16 at 14 59 25" src="https://github.com/user-attachments/assets/b43d2c2f-ca5d-4d60-9be0-19cd2bd30e86" />

<img width="683" height="291" alt="Screenshot 2026-06-16 at 14 58 34" src="https://github.com/user-attachments/assets/102d512d-4ca7-40ca-abf4-6dd5598cc065" />

