### PR TITLE
chore(pdc-dashboard): update the strapi-preview-button strapi plugin

### DIFF
--- a/.changeset/full-beans-repeat.md
+++ b/.changeset/full-beans-repeat.md
@@ -1,0 +1,13 @@
+---
+"@frameless/pdc-dashboard": minor
+---
+
+De knop is verplaatst en staat nu direct onder het standaard Preview-paneel van Strapi, in plaats van erboven.
+
+Ook is het uiterlijk van de knop aangepast, zodat deze dezelfde stijl heeft als de knop in het Preview-paneel van Strapi.
+
+Issues:
+
+- https://github.com/frameless/strapi/issues/1485
+- https://github.com/frameless/strapi/issues/1520
+- https://github.com/frameless/strapi/issues/1453

--- a/apps/pdc-dashboard/package.json
+++ b/apps/pdc-dashboard/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@frameless/content-compliance-checker": "1.0.3",
-    "@frameless/preview-button": "2.1.1",
+    "@frameless/preview-button": "2.2.0",
     "@frameless/strapi-plugin-env-label": "1.0.3",
     "@frameless/strapi-plugin-flo-legal-embed": "2.0.2",
     "@frameless/strapi-plugin-language": "1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: 1.0.3
         version: 1.0.3(e62097e51353b749636e699ad67079fe)
       '@frameless/preview-button':
-        specifier: 2.1.1
-        version: 2.1.1(873f23542f3711b5e4bfeccb503a77bb)
+        specifier: 2.2.0
+        version: 2.2.0(873f23542f3711b5e4bfeccb503a77bb)
       '@frameless/strapi-plugin-env-label':
         specifier: 1.0.3
         version: 1.0.3(1621872cbbeb1eafddeeaf0b649f5de8)
@@ -3266,8 +3266,8 @@ packages:
       eslint: ^9.39.3
       typescript: ^5.0.0
 
-  '@frameless/preview-button@2.1.1':
-    resolution: {integrity: sha512-dGoESxUKTQcsRRdLZAaqNXEAxAYkFa37O5MoutHGnaUVdr3mGv39nXv8SKq6Y5nNXhBFNWoZuZJRX5j6qsEzXw==}
+  '@frameless/preview-button@2.2.0':
+    resolution: {integrity: sha512-F9jfBGChUIM21BVa8wgbcOpSgcb0LEgme/6mKJHSW7QSSZkfiJmmgjvulDLoMTak3nXXNCZCbCMRsS0Ab1gStg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@strapi/design-system': '>=2.0.0'
@@ -22769,7 +22769,7 @@ snapshots:
       - supports-color
       - turbo
 
-  '@frameless/preview-button@2.1.1(873f23542f3711b5e4bfeccb503a77bb)':
+  '@frameless/preview-button@2.2.0(873f23542f3711b5e4bfeccb503a77bb)':
     dependencies:
       '@strapi/design-system': 2.2.0(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.16)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.1)(@types/react@18.3.12)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))


### PR DESCRIPTION
De knop is verplaatst en staat nu direct onder het standaard Preview-paneel van Strapi, in plaats van erboven.

Ook is het uiterlijk van de knop aangepast, zodat deze dezelfde stijl heeft als de knop in het Preview-paneel van Strapi.
