### PR TITLE
fix: buttonlink appearance change

### DIFF
--- a/.changeset/some-pans-pay.md
+++ b/.changeset/some-pans-pay.md
@@ -1,0 +1,9 @@
+---
+"@frameless/ui": patch
+---
+
+Fix: `ButtonLink` toonde altijd de primaire knopstijl, ongeacht de "Stijl" die was gekozen in het Call to Action-component in Strapi.
+
+Voorheen was de knopstijl hardcoded, waardoor de knop op de website nog steeds de standaard primaire stijl toonde, ook als een redacteur in Strapi een andere stijl had gekozen (bijv. "Aanvullende knop (wit)" of "Inwoners (blauw)"). De knop gebruikt nu de `buttonAppearance` prop, waardoor deze correct de stijl weergeeft die in het Strapi-dashboard is geselecteerd.
+
+([GitHub Issue Frameless/strapi#1534](https://github.com/frameless/strapi/issues/1534))

--- a/packages/ui/src/components/LogoButton/index.tsx
+++ b/packages/ui/src/components/LogoButton/index.tsx
@@ -123,7 +123,7 @@ export const LogoButton = ({ logo, appearance, href, children, label, headingLev
           {label && <Heading level={headingLevel}>{label}</Heading>}
           <ButtonGroup>
             <ButtonLink
-              appearance="primary-action-button"
+              appearance={buttonAppearance}
               href={href}
               className={isMagenta ? css('utrecht-button-link--magenta') : undefined}
             >


### PR DESCRIPTION
### Probleem
Secondaire button toont als primair (blauw) ipv wit
[Issue](https://github.com/orgs/frameless/projects/45/views/1?pane=issue&itemId=212877580&issue=frameless%7Cstrapi%7C1534)

### Opgeloste resultaat
<img width="500"  alt="Screenshot 2026-07-14 at 11 33 16" src="https://github.com/user-attachments/assets/3c034fe0-56c8-4c20-9f2d-885f62e2786a" />
<img width="500"  alt="Screenshot 2026-07-14 at 11 33 21" src="https://github.com/user-attachments/assets/9138d4f0-a8a0-4e2f-b21b-b6db3dd71b0a" />
